### PR TITLE
Add Thalos Prime epistemic computing v3 substrate

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -21,6 +21,7 @@
       "thalos.v3.claim.compile",
       "thalos.v3.challenge.plan",
       "thalos.v3.belief.classify",
+      "thalos.v3.decision.compile",
       "thalos.v3.program.run",
       "thalos.v3.witness.analyze",
       "thalos.v3.warrant.transform",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "thalos-prime",
-  "version": "0.2.0-alpha",
-  "description": "Sovereign epistemic workflows for deterministic retrieval, evidence binding, belief-state evaluation, provenance tracing, and replay.",
+  "version": "0.3.0-alpha",
+  "description": "Sovereign epistemic computing workflows for claim compilation, witness genealogy, challenge-driven verification, warrant conservation, belief lattices, deterministic replay, provenance, and proof export.",
   "mcp": {
     "server": "thalos-prime"
   },
@@ -16,7 +16,14 @@
       "thalos.search",
       "thalos.belief.get",
       "thalos.audit.trace",
-      "thalos.proof.export"
+      "thalos.proof.export",
+      "thalos.v3.claim.compile",
+      "thalos.v3.challenge.plan",
+      "thalos.v3.belief.classify",
+      "thalos.v3.program.run",
+      "thalos.v3.witness.analyze",
+      "thalos.v3.warrant.transform",
+      "thalos.v3.stability.analyze"
     ],
     "write": [
       "thalos.artifact.ingest",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -25,7 +25,8 @@
       "thalos.v3.witness.analyze",
       "thalos.v3.warrant.transform",
       "thalos.v3.stability.analyze",
-      "thalos.v3.counterfactual.analyze"
+      "thalos.v3.counterfactual.analyze",
+      "thalos.v3.transaction.build"
     ],
     "write": [
       "thalos.artifact.ingest",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -7,6 +7,7 @@
   },
   "skills": [
     "skills/epistemic-investigation/SKILL.md",
+    "skills/epistemic-v3-investigation/SKILL.md",
     "skills/source-verification/SKILL.md",
     "skills/forensic-analysis/SKILL.md",
     "skills/epistemic-audit/SKILL.md"
@@ -23,7 +24,8 @@
       "thalos.v3.program.run",
       "thalos.v3.witness.analyze",
       "thalos.v3.warrant.transform",
-      "thalos.v3.stability.analyze"
+      "thalos.v3.stability.analyze",
+      "thalos.v3.counterfactual.analyze"
     ],
     "write": [
       "thalos.artifact.ingest",

--- a/.github/workflows/epistemic-core.yml
+++ b/.github/workflows/epistemic-core.yml
@@ -12,6 +12,7 @@ on:
       - "tests/test_epistemic_v3.py"
       - "tests/test_counterfactual.py"
       - "tests/test_epistemic_transaction.py"
+      - "tests/test_decision_compiler.py"
       - ".github/workflows/epistemic-core.yml"
   push:
     branches:
@@ -27,6 +28,7 @@ on:
       - "tests/test_epistemic_v3.py"
       - "tests/test_counterfactual.py"
       - "tests/test_epistemic_transaction.py"
+      - "tests/test_decision_compiler.py"
       - ".github/workflows/epistemic-core.yml"
 
 permissions:
@@ -64,4 +66,5 @@ jobs:
             tests/test_persistent_epistemic_runtime.py \
             tests/test_epistemic_v3.py \
             tests/test_counterfactual.py \
-            tests/test_epistemic_transaction.py
+            tests/test_epistemic_transaction.py \
+            tests/test_decision_compiler.py

--- a/.github/workflows/epistemic-core.yml
+++ b/.github/workflows/epistemic-core.yml
@@ -10,6 +10,8 @@ on:
       - "tests/test_epistemic_core.py"
       - "tests/test_persistent_epistemic_runtime.py"
       - "tests/test_epistemic_v3.py"
+      - "tests/test_counterfactual.py"
+      - "tests/test_epistemic_transaction.py"
       - ".github/workflows/epistemic-core.yml"
   push:
     branches:
@@ -23,6 +25,8 @@ on:
       - "tests/test_epistemic_core.py"
       - "tests/test_persistent_epistemic_runtime.py"
       - "tests/test_epistemic_v3.py"
+      - "tests/test_counterfactual.py"
+      - "tests/test_epistemic_transaction.py"
       - ".github/workflows/epistemic-core.yml"
 
 permissions:
@@ -58,4 +62,6 @@ jobs:
           python -m pytest -q \
             tests/test_epistemic_core.py \
             tests/test_persistent_epistemic_runtime.py \
-            tests/test_epistemic_v3.py
+            tests/test_epistemic_v3.py \
+            tests/test_counterfactual.py \
+            tests/test_epistemic_transaction.py

--- a/.github/workflows/epistemic-core.yml
+++ b/.github/workflows/epistemic-core.yml
@@ -4,20 +4,25 @@ on:
   pull_request:
     paths:
       - "thalos_prime/epistemic_core.py"
+      - "thalos_prime/epistemic_v3/**"
       - "thalos_prime/mcp/**"
       - "thalos_prime/persistence/**"
       - "tests/test_epistemic_core.py"
       - "tests/test_persistent_epistemic_runtime.py"
+      - "tests/test_epistemic_v3.py"
       - ".github/workflows/epistemic-core.yml"
   push:
     branches:
       - "agent/epistemic-core-mcp-foundation"
+      - "agent/epistemic-v3-foundations"
     paths:
       - "thalos_prime/epistemic_core.py"
+      - "thalos_prime/epistemic_v3/**"
       - "thalos_prime/mcp/**"
       - "thalos_prime/persistence/**"
       - "tests/test_epistemic_core.py"
       - "tests/test_persistent_epistemic_runtime.py"
+      - "tests/test_epistemic_v3.py"
       - ".github/workflows/epistemic-core.yml"
 
 permissions:
@@ -44,11 +49,13 @@ jobs:
         run: |
           python -m compileall -q \
             thalos_prime/epistemic_core.py \
+            thalos_prime/epistemic_v3 \
             thalos_prime/mcp \
             thalos_prime/persistence
 
-      - name: Run epistemic core tests
+      - name: Run epistemic core and v3 tests
         run: |
           python -m pytest -q \
             tests/test_epistemic_core.py \
-            tests/test_persistent_epistemic_runtime.py
+            tests/test_persistent_epistemic_runtime.py \
+            tests/test_epistemic_v3.py

--- a/docs/THALOS_EPISTEMIC_V3.md
+++ b/docs/THALOS_EPISTEMIC_V3.md
@@ -37,7 +37,16 @@ Witness Calculus     Challenge Engine
         +-------+--------+
                 |
                 v
-        Epistemic VM
+         Decision Compiler
+                |
+                v
+      Epistemic Transaction
+                |
+                v
+        Epistemic VM / Replay
+                |
+                v
+        Proof + Provenance
                 |
                 v
         Transactional Ledger
@@ -96,7 +105,20 @@ Thalos does not reduce the epistemic state to a single confidence number. It kee
 - stability
 - reversibility
 
-The decision state is a policy outcome over those dimensions, not a claim about metaphysical truth.
+The belief state is not itself the final authority. The Decision Compiler applies explicit policy over the belief state plus stability and counterfactual analysis.
+
+### Decision compilation
+
+The Decision Compiler converts a computed belief state into a policy artifact with explicit reason codes.
+
+It can downgrade an apparently accepted claim to provisional when:
+
+- required challenges remain unresolved
+- the decision is fragile under perturbation
+- a small critical evidence set can flip the decision
+- contradiction is present
+
+The compiler also produces `safe_to_state_as_fact`, which is intentionally stricter than `accepted`.
 
 ### Counterfactual decision analysis
 
@@ -119,6 +141,26 @@ This produces:
 The result answers a more useful question than confidence:
 
 > What would have to change for this conclusion to change?
+
+### Immutable epistemic transaction
+
+The complete pre-commit computational state is represented by an `EpistemicTransaction` containing:
+
+- canonical Claim IR
+- challenge-plan identity
+- witness analysis
+- warrant state
+- belief-lattice position
+- final Decision Artifact
+- perturbation stability report
+- counterfactual report
+- source snapshot identity
+- run identity
+- proof-bundle identity
+
+The transaction is content-addressed. Its fingerprint excludes only the later durable commit-event reference, so committing the transaction does not alter the identity of the computation that produced it.
+
+The final decision artifact is part of the transaction itself. The transaction cannot be considered ready for commit unless its decision, stability baselines, counterfactual baselines, and unresolved-challenge state agree.
 
 ### Replayable epistemic VM
 
@@ -143,11 +185,13 @@ The v3 MCP tools are computational adapters, not the authority:
 thalos.v3.claim.compile
 thalos.v3.challenge.plan
 thalos.v3.belief.classify
+thalos.v3.decision.compile
 thalos.v3.program.run
 thalos.v3.witness.analyze
 thalos.v3.warrant.transform
 thalos.v3.stability.analyze
 thalos.v3.counterfactual.analyze
+thalos.v3.transaction.build
 ```
 
 None of these tools directly commits durable belief state.
@@ -169,8 +213,10 @@ Durable commitment remains behind the existing transactional ledger and approval
 10. Classify the claim in the Belief Lattice.
 11. Run perturbation stability analysis.
 12. Run counterfactual evidence analysis.
-13. Generate proof and provenance package.
-14. Commit to durable ledger only through policy-controlled transaction.
+13. Compile the final policy Decision Artifact.
+14. Build the immutable Epistemic Transaction containing the Decision Artifact.
+15. Generate proof and provenance package.
+16. Commit to durable ledger only through policy-controlled transaction and authorization.
 ```
 
 ## What v3 does not claim
@@ -194,7 +240,7 @@ The next safe extensions are:
 3. Temporal interval algebra with explicit uncertainty bounds.
 4. Evidence replacement and substitution counterfactuals.
 5. Signed transparency logs over committed epistemic events.
-6. Independent proof-bundle verification for v3 lattice and counterfactual outputs.
-7. Benchmark datasets for stability, witness correlation, and appropriate abstention.
+6. Independent proof-bundle verification for v3 lattice, decision, and counterfactual outputs.
+7. Benchmark datasets for stability, witness correlation, appropriate abstention, and decision sensitivity.
 
 Advanced cryptographic proofs, distributed consensus, and learned semantic retrieval should remain downstream of these primitives rather than defining them.

--- a/docs/THALOS_EPISTEMIC_V3.md
+++ b/docs/THALOS_EPISTEMIC_V3.md
@@ -1,0 +1,200 @@
+# Thalos Prime Epistemic Computing v3
+
+## Purpose
+
+The v3 layer changes Thalos Prime from a source-and-confidence system into a replayable epistemic computation substrate.
+
+The current transactional foundation remains authoritative for durable state. v3 supplies the computation performed before a belief transition is committed.
+
+```text
+Natural language
+      |
+      v
+Claim Compiler
+      |
+      v
+Claim IR
+      |
+      +-------------------+
+      |                   |
+      v                   v
+Witness Calculus     Challenge Engine
+      |                   |
+      +---------+---------+
+                |
+                v
+          Warrant Algebra
+                |
+                v
+          Belief Lattice
+                |
+        +-------+--------+
+        |                |
+        v                v
+ Perturbation       Counterfactual
+ Stability           Decision Surface
+        |                |
+        +-------+--------+
+                |
+                v
+        Epistemic VM
+                |
+                v
+        Transactional Ledger
+```
+
+## Core invariants
+
+### Epistemic conservation
+
+A transformation cannot create usable warrant for free.
+
+- Copy preserves warrant.
+- Paraphrase preserves or reduces warrant.
+- Summarization preserves or reduces warrant.
+- Deduction is bounded by premise warrant and formal validity.
+- Corroboration can increase warrant only through explicitly modeled independent evidence.
+- Contradiction increases visible conflict; it never deletes prior support.
+- Speculation becomes a search hypothesis and does not inherit factual warrant.
+
+The system therefore separates **hypothesis generation** from **warrant acquisition**.
+
+### Witness independence
+
+Ten documents are not ten independent witnesses when nine derive from the first.
+
+Witnesses carry causal parent relationships. The Witness Calculus groups witnesses by lineage and independence group before support is aggregated.
+
+### Falsification shadow
+
+Every claim receives deterministic challenge tasks for:
+
+- counterevidence
+- source dependence
+- temporal scope
+- claim scope
+- causal alternatives when applicable
+- identity ambiguity when applicable
+- measurement failure when applicable
+
+An accepted decision with unresolved challenges is not equivalent to a stable fact.
+
+### Multidimensional belief state
+
+Thalos does not reduce the epistemic state to a single confidence number. It keeps independent dimensions:
+
+- support
+- contradiction
+- entailment
+- temporal validity
+- scope validity
+- witness independence
+- provenance integrity
+- reproducibility
+- falsifiability
+- information state
+- stability
+- reversibility
+
+The decision state is a policy outcome over those dimensions, not a claim about metaphysical truth.
+
+### Counterfactual decision analysis
+
+For an evidence set `E`, Thalos can evaluate:
+
+```text
+Decision(E)
+Decision(E - {e1})
+Decision(E - {e2})
+Decision(E - {e1,e2})
+...
+```
+
+This produces:
+
+- critical evidence: evidence whose removal can flip the decision
+- robust evidence: evidence whose removal does not change the decision
+- minimal flip sets: smallest detected removals that reverse the decision
+
+The result answers a more useful question than confidence:
+
+> What would have to change for this conclusion to change?
+
+### Replayable epistemic VM
+
+The v3 VM contains pure deterministic operations and no network or model calls:
+
+```text
+COMPILE_CLAIM
+BUILD_CHALLENGE_PLAN
+CLASSIFY_BELIEF
+EMIT_RESULT
+```
+
+A model may propose a richer claim parse or evidence hypothesis, but the resulting object must be validated before entering the VM.
+
+The VM execution fingerprint is derived from the program, serialized state, claim identity, belief position, and challenge plan identity.
+
+## MCP boundary
+
+The v3 MCP tools are computational adapters, not the authority:
+
+```text
+thalos.v3.claim.compile
+thalos.v3.challenge.plan
+thalos.v3.belief.classify
+thalos.v3.program.run
+thalos.v3.witness.analyze
+thalos.v3.warrant.transform
+thalos.v3.stability.analyze
+thalos.v3.counterfactual.analyze
+```
+
+None of these tools directly commits durable belief state.
+
+Durable commitment remains behind the existing transactional ledger and approval boundary.
+
+## Recommended workflow
+
+```text
+1. Compile user question into Claim IR.
+2. Build falsification shadow.
+3. Retrieve candidate sources into a frozen snapshot.
+4. Construct witnesses and causal genealogy.
+5. Bind exact evidence spans.
+6. Evaluate support and contradiction separately.
+7. Aggregate independent witnesses through Witness Calculus.
+8. Apply Warrant Algebra transformations explicitly.
+9. Run required challenge tasks.
+10. Classify the claim in the Belief Lattice.
+11. Run perturbation stability analysis.
+12. Run counterfactual evidence analysis.
+13. Generate proof and provenance package.
+14. Commit to durable ledger only through policy-controlled transaction.
+```
+
+## What v3 does not claim
+
+v3 is not a truth oracle.
+
+It does not prove that a source is truthful merely because it is primary.
+It does not prove causation merely from temporal sequence.
+It does not turn model output into evidence.
+It does not treat source count as independence.
+It does not guarantee real-world truth from logical consistency.
+
+The architecture instead guarantees that the system's own epistemic operations are explicit, versioned, replayable, and inspectable.
+
+## Future extension points
+
+The next safe extensions are:
+
+1. Claim-IR enrichment with a validated semantic parser.
+2. Causal challenge programs for intervention and confounding analysis.
+3. Temporal interval algebra with explicit uncertainty bounds.
+4. Evidence replacement and substitution counterfactuals.
+5. Signed transparency logs over committed epistemic events.
+6. Independent proof-bundle verification for v3 lattice and counterfactual outputs.
+7. Benchmark datasets for stability, witness correlation, and appropriate abstention.
+
+Advanced cryptographic proofs, distributed consensus, and learned semantic retrieval should remain downstream of these primitives rather than defining them.

--- a/skills/epistemic-v3-investigation/SKILL.md
+++ b/skills/epistemic-v3-investigation/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: epistemic-v3-investigation
+description: Execute a Thalos Prime v3 investigation using Claim IR, Witness Calculus, falsification challenges, warrant transformations, belief-lattice classification, stability testing, and counterfactual evidence analysis before any durable belief commit.
+---
+
+# Thalos Prime Epistemic v3 Investigation
+
+Use this workflow when the task requires more than retrieving sources. The objective is to construct a replayable epistemic transaction, not merely produce a fluent answer.
+
+## Required sequence
+
+1. Compile the user's question with `thalos.v3.claim.compile`.
+2. Inspect compiler warnings. Do not silently invent semantic slots, temporal scope, or claim type.
+3. Build the falsification shadow using `thalos.v3.challenge.plan`.
+4. Ingest or locate admissible source artifacts and freeze the source snapshot.
+5. Retrieve candidate evidence only from the frozen snapshot.
+6. Bind exact evidence spans to source artifacts.
+7. Construct witnesses for supporting and contradicting evidence.
+8. Use `thalos.v3.witness.analyze` to detect source genealogy and correlation.
+9. Use `thalos.v3.warrant.transform` to make every warrant-changing operation explicit.
+10. Treat model-generated hypotheses as speculation until evidence enters the warrant system.
+11. Execute required challenge tasks, including counterevidence search and source-dependence checks.
+12. Classify the evidence using `thalos.v3.belief.classify`.
+13. Run `thalos.v3.stability.analyze` to test sensitivity to valid perturbations.
+14. Run `thalos.v3.counterfactual.analyze` to identify minimal evidence sets that would flip the decision.
+15. Build a complete epistemic transaction record containing all intermediate identities and fingerprints.
+16. Only then pass the transaction to the durable ledger commit path.
+
+## Epistemic rules
+
+- A source count is not an independence count.
+- A primary source can still be wrong.
+- Correlated copies count as one witness lineage unless independent observation is established.
+- Logical validity does not establish premise warrant.
+- Model fluency does not create evidence.
+- Summarization and paraphrase cannot increase warrant.
+- Contradicting evidence must remain visible even when support is strong.
+- A provisional or disputed conclusion must not be presented as settled fact.
+- An unresolved challenge is part of the epistemic state and must be reported.
+- A stable conclusion must still preserve its falsification conditions.
+- Durable belief changes require the existing authorization and approval boundary.
+
+## Output contract
+
+Return:
+
+- canonical claim IR
+- compiler warnings
+- challenge plan and unresolved tasks
+- source snapshot ID
+- witness genealogy and independence analysis
+- supporting evidence
+- contradicting evidence
+- warrant state and transformation history
+- belief-lattice position
+- stability report
+- counterfactual report
+- epistemic transaction ID/fingerprint
+- durable ledger state only if a separately authorized commit occurred
+
+Do not reduce the entire transaction to one confidence score.

--- a/skills/epistemic-v3-investigation/SKILL.md
+++ b/skills/epistemic-v3-investigation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: epistemic-v3-investigation
-description: Execute a Thalos Prime v3 investigation using Claim IR, Witness Calculus, falsification challenges, warrant transformations, belief-lattice classification, stability testing, and counterfactual evidence analysis before any durable belief commit.
+description: Execute a Thalos Prime v3 investigation using Claim IR, Witness Calculus, falsification challenges, warrant transformations, belief-lattice classification, decision compilation, stability testing, counterfactual evidence analysis, and immutable transaction assembly before any durable belief commit.
 ---
 
 # Thalos Prime Epistemic v3 Investigation
@@ -23,8 +23,9 @@ Use this workflow when the task requires more than retrieving sources. The objec
 12. Classify the evidence using `thalos.v3.belief.classify`.
 13. Run `thalos.v3.stability.analyze` to test sensitivity to valid perturbations.
 14. Run `thalos.v3.counterfactual.analyze` to identify minimal evidence sets that would flip the decision.
-15. Build a complete epistemic transaction record containing all intermediate identities and fingerprints.
-16. Only then pass the transaction to the durable ledger commit path.
+15. Compile the final policy decision with `thalos.v3.decision.compile`.
+16. Build the immutable transaction with `thalos.v3.transaction.build`, including the final Decision Artifact.
+17. Only then pass the transaction to the durable ledger commit path.
 
 ## Epistemic rules
 
@@ -38,6 +39,8 @@ Use this workflow when the task requires more than retrieving sources. The objec
 - A provisional or disputed conclusion must not be presented as settled fact.
 - An unresolved challenge is part of the epistemic state and must be reported.
 - A stable conclusion must still preserve its falsification conditions.
+- The final Decision Artifact is a policy result, not a claim of metaphysical truth.
+- The immutable transaction must contain the decision artifact that was compiled from the exact stability and counterfactual analyses used to justify it.
 - Durable belief changes require the existing authorization and approval boundary.
 
 ## Output contract
@@ -55,7 +58,8 @@ Return:
 - belief-lattice position
 - stability report
 - counterfactual report
-- epistemic transaction ID/fingerprint
+- final Decision Artifact and reason codes
+- immutable epistemic transaction ID/fingerprint
 - durable ledger state only if a separately authorized commit occurred
 
 Do not reduce the entire transaction to one confidence score.

--- a/tests/test_counterfactual.py
+++ b/tests/test_counterfactual.py
@@ -1,0 +1,41 @@
+"""Tests for counterfactual evidence analysis."""
+
+from __future__ import annotations
+
+from thalos_prime.epistemic_v3.counterfactual import CounterfactualEngine
+
+
+def test_counterfactual_engine_finds_minimal_flip() -> None:
+    engine = CounterfactualEngine(max_removal_order=2)
+
+    def decide(ids: tuple[str, ...]) -> str:
+        return "accepted" if {"a", "b"}.issubset(ids) else "pending"
+
+    report = engine.analyze(
+        evidence_ids=("a", "b", "c"),
+        baseline_decision="accepted",
+        decide=decide,
+    )
+    assert report.cases_examined == 6
+    assert report.minimal_flip_cases
+    assert ("a",) in {case.removed_evidence for case in report.minimal_flip_cases}
+    assert ("b",) in {case.removed_evidence for case in report.minimal_flip_cases}
+    assert "a" in report.critical_evidence
+    assert "b" in report.critical_evidence
+    assert "c" not in report.critical_evidence
+    assert "c" in report.robust_evidence
+
+
+def test_counterfactual_engine_reports_no_flip_for_redundant_evidence() -> None:
+    engine = CounterfactualEngine(max_removal_order=1)
+
+    def decide(ids: tuple[str, ...]) -> str:
+        return "accepted" if len(ids) >= 2 else "pending"
+
+    report = engine.analyze(
+        evidence_ids=("a", "b", "c"),
+        baseline_decision="accepted",
+        decide=decide,
+    )
+    assert report.minimal_flip_cases
+    assert report.critical_evidence == ("a", "b", "c")

--- a/tests/test_counterfactual.py
+++ b/tests/test_counterfactual.py
@@ -37,5 +37,7 @@ def test_counterfactual_engine_reports_no_flip_for_redundant_evidence() -> None:
         baseline_decision="accepted",
         decide=decide,
     )
-    assert report.minimal_flip_cases
-    assert report.critical_evidence == ("a", "b", "c")
+    assert report.flip_cases == ()
+    assert report.minimal_flip_cases == ()
+    assert report.critical_evidence == ()
+    assert report.robust_evidence == ("a", "b", "c")

--- a/tests/test_decision_compiler.py
+++ b/tests/test_decision_compiler.py
@@ -1,0 +1,94 @@
+"""Tests for explicit Thalos Prime decision compilation."""
+
+from __future__ import annotations
+
+from thalos_prime.epistemic_v3.counterfactual import CounterfactualEngine
+from thalos_prime.epistemic_v3.decision import DecisionCompiler, DecisionReason
+from thalos_prime.epistemic_v3.lattice import BeliefLattice, DecisionState
+from thalos_prime.epistemic_v3.stability import StabilityAnalyzer
+from thalos_prime.epistemic_v3.warrant import Warrant
+
+
+def _warrant(**overrides: float) -> Warrant:
+    values = {
+        "support": 0.95,
+        "contradiction": 0.0,
+        "entailment": 0.95,
+        "temporal_validity": 1.0,
+        "scope_validity": 0.95,
+        "independence": 0.95,
+        "provenance_integrity": 1.0,
+        "reproducibility": 1.0,
+        "falsifiability": 0.95,
+    }
+    values.update(overrides)
+    return Warrant(**values)
+
+
+def test_decision_compiler_downgrades_fragile_acceptance() -> None:
+    belief = BeliefLattice().classify(
+        claim_id="clmir:test",
+        warrant=_warrant(),
+        challenge_count=0,
+        resolved_challenge_count=0,
+        failed_challenge_count=0,
+    )
+
+    def decide(ids: tuple[str, ...]) -> str:
+        return "accepted" if len(ids) >= 2 else "pending"
+
+    stability = StabilityAnalyzer().analyze(
+        evidence_ids=("a", "b"),
+        baseline_decision="accepted",
+        decide=decide,
+        max_removals=1,
+    )
+    counterfactual = CounterfactualEngine(max_removal_order=1).analyze(
+        evidence_ids=("a", "b"),
+        baseline_decision="accepted",
+        decide=decide,
+    )
+    artifact = DecisionCompiler().compile(
+        belief=belief,
+        stability=stability,
+        counterfactual=counterfactual,
+    )
+    assert artifact.input_decision is DecisionState.ACCEPTED
+    assert artifact.final_decision is DecisionState.PROVISIONAL
+    assert DecisionReason.STABILITY_LOW in artifact.reasons
+    assert DecisionReason.CRITICAL_EVIDENCE in artifact.reasons
+    assert artifact.safe_to_state_as_fact is False
+
+
+def test_decision_compiler_keeps_stable_redundant_acceptance() -> None:
+    belief = BeliefLattice().classify(
+        claim_id="clmir:test",
+        warrant=_warrant(),
+        challenge_count=0,
+        resolved_challenge_count=0,
+        failed_challenge_count=0,
+    )
+
+    def decide(ids: tuple[str, ...]) -> str:
+        return "accepted"
+
+    evidence = ("a", "b", "c")
+    stability = StabilityAnalyzer().analyze(
+        evidence_ids=evidence,
+        baseline_decision="accepted",
+        decide=decide,
+        max_removals=1,
+    )
+    counterfactual = CounterfactualEngine(max_removal_order=1).analyze(
+        evidence_ids=evidence,
+        baseline_decision="accepted",
+        decide=decide,
+    )
+    artifact = DecisionCompiler().compile(
+        belief=belief,
+        stability=stability,
+        counterfactual=counterfactual,
+    )
+    assert artifact.final_decision is DecisionState.ACCEPTED
+    assert artifact.safe_to_state_as_fact is True
+    assert DecisionReason.STABLE_AND_REDUNDANT in artifact.reasons

--- a/tests/test_epistemic_transaction.py
+++ b/tests/test_epistemic_transaction.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from thalos_prime.epistemic_v3.challenge import ChallengeEngine
 from thalos_prime.epistemic_v3.claim_ir import ClaimCompiler
 from thalos_prime.epistemic_v3.counterfactual import CounterfactualEngine
+from thalos_prime.epistemic_v3.decision import DecisionCompiler
 from thalos_prime.epistemic_v3.lattice import BeliefLattice
 from thalos_prime.epistemic_v3.stability import StabilityAnalyzer
 from thalos_prime.epistemic_v3.transaction import EpistemicTransaction
@@ -51,12 +52,18 @@ def test_transaction_fingerprint_is_content_addressed() -> None:
         baseline_decision=belief.decision.value,
         decide=decide,
     )
+    decision_artifact = DecisionCompiler().compile(
+        belief=belief,
+        stability=stability,
+        counterfactual=counterfactual,
+    )
     first = EpistemicTransaction.create(
         claim=claim,
         challenge_plan_id=plan.plan_id,
         witness_analysis=witness_analysis,
         warrant=warrant,
         belief_position=belief,
+        decision_artifact=decision_artifact,
         stability_report=stability,
         counterfactual_report=counterfactual,
     )
@@ -66,6 +73,7 @@ def test_transaction_fingerprint_is_content_addressed() -> None:
         witness_analysis=witness_analysis,
         warrant=warrant,
         belief_position=belief,
+        decision_artifact=decision_artifact,
         stability_report=stability,
         counterfactual_report=counterfactual,
     )
@@ -106,15 +114,22 @@ def test_transaction_commit_binding_changes_only_commit_reference() -> None:
         baseline_decision=belief.decision.value,
         decide=lambda _: belief.decision.value,
     )
+    decision_artifact = DecisionCompiler().compile(
+        belief=belief,
+        stability=stability,
+        counterfactual=counterfactual,
+    )
     txn = EpistemicTransaction.create(
         claim=claim,
         challenge_plan_id=plan.plan_id,
         witness_analysis={},
         warrant=warrant,
         belief_position=belief,
+        decision_artifact=decision_artifact,
         stability_report=stability,
         counterfactual_report=counterfactual,
     )
+    assert txn.ready_for_commit is False
     bound = txn.bind_commit("evt:123")
     assert txn.transaction_id == bound.transaction_id
     assert txn.fingerprint == bound.fingerprint

--- a/tests/test_epistemic_transaction.py
+++ b/tests/test_epistemic_transaction.py
@@ -1,0 +1,121 @@
+"""Tests for immutable epistemic transaction aggregation."""
+
+from __future__ import annotations
+
+from thalos_prime.epistemic_v3.challenge import ChallengeEngine
+from thalos_prime.epistemic_v3.claim_ir import ClaimCompiler
+from thalos_prime.epistemic_v3.counterfactual import CounterfactualEngine
+from thalos_prime.epistemic_v3.lattice import BeliefLattice
+from thalos_prime.epistemic_v3.stability import StabilityAnalyzer
+from thalos_prime.epistemic_v3.transaction import EpistemicTransaction
+from thalos_prime.epistemic_v3.warrant import Warrant
+from thalos_prime.epistemic_v3.witness import Witness, WitnessCalculus, WitnessKind
+
+
+def test_transaction_fingerprint_is_content_addressed() -> None:
+    claim = ClaimCompiler.compile("Revenue increased in 2025.").claim
+    plan = ChallengeEngine.build_plan(claim)
+    witness = Witness.create("src:1", WitnessKind.RECORD, issuer="A")
+    witness_analysis = WitnessCalculus([witness]).analyze([witness.witness_id])
+    warrant = Warrant(
+        support=0.9,
+        contradiction=0.0,
+        entailment=0.9,
+        temporal_validity=1.0,
+        scope_validity=0.9,
+        independence=1.0,
+        provenance_integrity=1.0,
+        reproducibility=1.0,
+        falsifiability=1.0,
+    )
+    lattice = BeliefLattice()
+    belief = lattice.classify(
+        claim_id=claim.claim_id,
+        warrant=warrant,
+        challenge_count=0,
+        resolved_challenge_count=0,
+        failed_challenge_count=0,
+    )
+
+    def decide(ids: tuple[str, ...]) -> str:
+        return belief.decision.value
+
+    stability = StabilityAnalyzer().analyze(
+        evidence_ids=(witness.witness_id,),
+        baseline_decision=belief.decision.value,
+        decide=decide,
+        max_removals=1,
+    )
+    counterfactual = CounterfactualEngine(max_removal_order=1).analyze(
+        evidence_ids=(witness.witness_id,),
+        baseline_decision=belief.decision.value,
+        decide=decide,
+    )
+    first = EpistemicTransaction.create(
+        claim=claim,
+        challenge_plan_id=plan.plan_id,
+        witness_analysis=witness_analysis,
+        warrant=warrant,
+        belief_position=belief,
+        stability_report=stability,
+        counterfactual_report=counterfactual,
+    )
+    second = EpistemicTransaction.create(
+        claim=claim,
+        challenge_plan_id=plan.plan_id,
+        witness_analysis=witness_analysis,
+        warrant=warrant,
+        belief_position=belief,
+        stability_report=stability,
+        counterfactual_report=counterfactual,
+    )
+    assert first.transaction_id == second.transaction_id
+    assert first.fingerprint == second.fingerprint
+    assert first.ready_for_commit is True
+
+
+def test_transaction_commit_binding_changes_only_commit_reference() -> None:
+    claim = ClaimCompiler.compile("Revenue increased.").claim
+    plan = ChallengeEngine.build_plan(claim)
+    warrant = Warrant(
+        support=0.6,
+        contradiction=0.0,
+        entailment=0.7,
+        temporal_validity=1.0,
+        scope_validity=0.8,
+        independence=0.7,
+        provenance_integrity=1.0,
+        reproducibility=1.0,
+        falsifiability=0.8,
+    )
+    belief = BeliefLattice().classify(
+        claim_id=claim.claim_id,
+        warrant=warrant,
+        challenge_count=1,
+        resolved_challenge_count=0,
+        failed_challenge_count=0,
+    )
+    stability = StabilityAnalyzer().analyze(
+        evidence_ids=(),
+        baseline_decision=belief.decision.value,
+        decide=lambda _: belief.decision.value,
+        max_removals=1,
+    )
+    counterfactual = CounterfactualEngine().analyze(
+        evidence_ids=(),
+        baseline_decision=belief.decision.value,
+        decide=lambda _: belief.decision.value,
+    )
+    txn = EpistemicTransaction.create(
+        claim=claim,
+        challenge_plan_id=plan.plan_id,
+        witness_analysis={},
+        warrant=warrant,
+        belief_position=belief,
+        stability_report=stability,
+        counterfactual_report=counterfactual,
+    )
+    bound = txn.bind_commit("evt:123")
+    assert txn.transaction_id == bound.transaction_id
+    assert txn.fingerprint == bound.fingerprint
+    assert bound.committed_event_id == "evt:123"

--- a/tests/test_epistemic_v3.py
+++ b/tests/test_epistemic_v3.py
@@ -59,8 +59,18 @@ def test_witness_calculus_detects_derived_source_correlation() -> None:
 
 
 def test_witness_calculus_rejects_genealogy_cycles() -> None:
-    first = Witness.create("src:first", WitnessKind.DERIVED, parent_witness_ids=["wit:second"])
-    second = Witness.create("src:second", WitnessKind.DERIVED, parent_witness_ids=[first.witness_id])
+    first = Witness(
+        witness_id="wit:first",
+        artifact_id="src:first",
+        kind=WitnessKind.DERIVED,
+        parent_witness_ids=("wit:second",),
+    )
+    second = Witness(
+        witness_id="wit:second",
+        artifact_id="src:second",
+        kind=WitnessKind.DERIVED,
+        parent_witness_ids=("wit:first",),
+    )
     try:
         WitnessCalculus([first, second])
     except ValueError as exc:

--- a/tests/test_epistemic_v3.py
+++ b/tests/test_epistemic_v3.py
@@ -1,0 +1,163 @@
+"""Tests for the Thalos Prime epistemic computing v3 layer."""
+
+from __future__ import annotations
+
+from thalos_prime.epistemic_v3.challenge import ChallengeEngine, ChallengeKind
+from thalos_prime.epistemic_v3.claim_ir import ClaimCompiler, ClaimType
+from thalos_prime.epistemic_v3.lattice import BeliefLattice, DecisionState, StabilityState
+from thalos_prime.epistemic_v3.stability import StabilityAnalyzer
+from thalos_prime.epistemic_v3.vm import DEFAULT_INVESTIGATION_PROGRAM, EpistemicVM
+from thalos_prime.epistemic_v3.warrant import Warrant, WarrantAlgebra
+from thalos_prime.epistemic_v3.witness import Witness, WitnessCalculus, WitnessKind
+
+
+def _warrant(**overrides: float) -> Warrant:
+    values = {
+        "support": 0.9,
+        "contradiction": 0.0,
+        "entailment": 0.95,
+        "temporal_validity": 1.0,
+        "scope_validity": 0.95,
+        "independence": 0.9,
+        "provenance_integrity": 1.0,
+        "reproducibility": 1.0,
+        "falsifiability": 0.9,
+    }
+    values.update(overrides)
+    return Warrant(**values)
+
+
+def test_claim_compiler_produces_stable_identity_and_temporal_scope() -> None:
+    first = ClaimCompiler.compile("Revenue increased in 2025.")
+    second = ClaimCompiler.compile("Revenue increased in 2025.")
+    assert first.claim.claim_id == second.claim.claim_id
+    assert first.claim.claim_type is ClaimType.TEMPORAL
+    assert first.claim.valid_from == "2025"
+    assert first.claim.valid_to == "2025"
+    assert any("semantic slots" in warning for warning in first.warnings)
+
+
+def test_claim_compiler_does_not_invent_semantic_slots() -> None:
+    result = ClaimCompiler.compile("The bridge caused traffic to increase.")
+    assert result.claim.claim_type is ClaimType.CAUSAL
+    assert result.claim.subject is None
+    assert result.claim.predicate is None
+    assert result.claim.object is None
+
+
+def test_witness_calculus_detects_derived_source_correlation() -> None:
+    root = Witness.create("src:root", WitnessKind.RECORD, issuer="A")
+    derived_a = Witness.create("src:a", WitnessKind.DERIVED, issuer="B", parent_witness_ids=[root.witness_id])
+    derived_b = Witness.create("src:b", WitnessKind.DERIVED, issuer="C", parent_witness_ids=[root.witness_id])
+    independent = Witness.create("src:d", WitnessKind.MEASUREMENT, issuer="D")
+    analysis = WitnessCalculus([root, derived_a, derived_b, independent]).analyze(
+        [derived_a.witness_id, derived_b.witness_id, independent.witness_id]
+    )
+    assert len(analysis.root_lineages) == 2
+    assert analysis.correlation_penalty > 0.0
+    assert len(analysis.independent_groups) == 2
+
+
+def test_witness_calculus_rejects_genealogy_cycles() -> None:
+    first = Witness.create("src:first", WitnessKind.DERIVED, parent_witness_ids=["wit:second"])
+    second = Witness.create("src:second", WitnessKind.DERIVED, parent_witness_ids=[first.witness_id])
+    try:
+        WitnessCalculus([first, second])
+    except ValueError as exc:
+        assert "cycle" in str(exc).lower()
+    else:
+        raise AssertionError("Expected cyclic witness genealogy to be rejected")
+
+
+def test_warrant_algebra_preserves_or_explicitly_accounts_for_warrant_transfer() -> None:
+    base = _warrant()
+    paraphrase = WarrantAlgebra.paraphrase(base, fidelity=0.8)
+    assert paraphrase.output_warrant.usable_support <= base.usable_support
+    assert paraphrase.conserved
+
+    speculative = WarrantAlgebra.speculate(base)
+    assert speculative.output_warrant.support == 0.0
+    assert speculative.conserved
+
+    corroborated = WarrantAlgebra.corroborate([base, _warrant(support=0.7)], independence=1.0)
+    assert corroborated.output_warrant.support >= base.support
+    assert corroborated.operation.value == "corroborate"
+    assert corroborated.rule_id == "warrant.corroborate.v1"
+
+
+def test_challenge_engine_generates_causal_falsification_shadow() -> None:
+    claim = ClaimCompiler.compile("Policy X caused unemployment to fall.").claim
+    plan = ChallengeEngine.build_plan(claim)
+    kinds = {task.kind for task in plan.tasks}
+    assert ChallengeKind.COUNTEREVIDENCE in kinds
+    assert ChallengeKind.CAUSAL in kinds
+    assert ChallengeKind.ALTERNATIVE_EXPLANATION in kinds
+    assert plan.required_task_count >= 6
+
+
+def test_belief_lattice_keeps_contradiction_visible() -> None:
+    lattice = BeliefLattice()
+    position = lattice.classify(
+        claim_id="clmir:test",
+        warrant=_warrant(contradiction=0.8),
+        challenge_count=4,
+        resolved_challenge_count=2,
+        failed_challenge_count=0,
+    )
+    assert position.decision is DecisionState.DISPUTED
+    assert position.information_state.value == "both"
+    assert position.unresolved_challenges == 2
+    assert position.stability in {StabilityState.STABLE, StabilityState.MODERATE}
+
+
+def test_epistemic_vm_is_replayable_for_same_inputs() -> None:
+    vm = EpistemicVM()
+    inputs = {
+        "query": "Revenue increased in 2025.",
+        "warrant": _warrant(),
+        "challenge_count": 0,
+        "resolved_challenge_count": 0,
+        "failed_challenge_count": 0,
+    }
+    first = vm.execute(DEFAULT_INVESTIGATION_PROGRAM, inputs)
+    second = vm.execute(DEFAULT_INVESTIGATION_PROGRAM, inputs)
+    assert first.execution_fingerprint == second.execution_fingerprint
+    assert first.claim is not None
+    assert first.challenge_plan_id is not None
+    assert first.belief is not None
+    assert first.belief.decision is DecisionState.ACCEPTED
+
+
+def test_stability_analyzer_detects_fragile_decision() -> None:
+    analyzer = StabilityAnalyzer()
+
+    def decide(ids: tuple[str, ...]) -> str:
+        return "accepted" if len(ids) >= 2 else "pending"
+
+    report = analyzer.analyze(
+        evidence_ids=("ev:a", "ev:b"),
+        baseline_decision="accepted",
+        decide=decide,
+        max_removals=1,
+    )
+    assert report.perturbation_count == 3
+    assert report.changed_decision_count == 2
+    assert report.stability_score < 0.5
+    assert report.reversibility_score > 0.5
+
+
+def test_stability_analyzer_is_order_invariant_for_reordering() -> None:
+    analyzer = StabilityAnalyzer()
+
+    def decide(ids: tuple[str, ...]) -> str:
+        return "accepted" if set(ids) == {"a", "b"} else "pending"
+
+    report = analyzer.analyze(
+        evidence_ids=("a", "b"),
+        baseline_decision="accepted",
+        decide=decide,
+        max_removals=0,
+    )
+    assert report.perturbation_count == 1
+    assert report.changed_decision_count == 0
+    assert report.stability_score == 1.0

--- a/thalos_prime/epistemic_v3/__init__.py
+++ b/thalos_prime/epistemic_v3/__init__.py
@@ -1,15 +1,17 @@
 """Thalos Prime epistemic computing layer v3.
 
 This package introduces the Claim IR, Witness Calculus, Warrant Algebra,
-challenge/falsification engine, belief lattice, epistemic VM, perturbation
-stability analysis, counterfactual decision analysis, and immutable epistemic
-transactions. It sits above the transactional foundation without coupling
-epistemic computation to MCP or any model provider.
+challenge/falsification engine, belief lattice, decision compiler,
+epistemic VM, perturbation stability analysis, counterfactual decision
+analysis, and immutable epistemic transactions. It sits above the
+transactional foundation without coupling epistemic computation to MCP or
+any model provider.
 """
 
 from thalos_prime.epistemic_v3.challenge import ChallengeEngine, ChallengePlan
 from thalos_prime.epistemic_v3.claim_ir import ClaimCompiler, ClaimIR
 from thalos_prime.epistemic_v3.counterfactual import CounterfactualEngine, CounterfactualReport
+from thalos_prime.epistemic_v3.decision import DecisionArtifact, DecisionCompiler, DecisionReason
 from thalos_prime.epistemic_v3.lattice import BeliefLattice, BeliefPosition
 from thalos_prime.epistemic_v3.stability import StabilityAnalyzer, StabilityReport
 from thalos_prime.epistemic_v3.transaction import EpistemicTransaction
@@ -26,6 +28,9 @@ __all__ = [
     "ClaimIR",
     "CounterfactualEngine",
     "CounterfactualReport",
+    "DecisionArtifact",
+    "DecisionCompiler",
+    "DecisionReason",
     "EpistemicProgram",
     "EpistemicTransaction",
     "EpistemicVM",

--- a/thalos_prime/epistemic_v3/__init__.py
+++ b/thalos_prime/epistemic_v3/__init__.py
@@ -2,9 +2,9 @@
 
 This package introduces the Claim IR, Witness Calculus, Warrant Algebra,
 challenge/falsification engine, belief lattice, epistemic VM, perturbation
-stability analysis, and counterfactual decision analysis. It sits above the
-transactional foundation without coupling epistemic computation to MCP or
-any model provider.
+stability analysis, counterfactual decision analysis, and immutable epistemic
+transactions. It sits above the transactional foundation without coupling
+epistemic computation to MCP or any model provider.
 """
 
 from thalos_prime.epistemic_v3.challenge import ChallengeEngine, ChallengePlan
@@ -12,6 +12,7 @@ from thalos_prime.epistemic_v3.claim_ir import ClaimCompiler, ClaimIR
 from thalos_prime.epistemic_v3.counterfactual import CounterfactualEngine, CounterfactualReport
 from thalos_prime.epistemic_v3.lattice import BeliefLattice, BeliefPosition
 from thalos_prime.epistemic_v3.stability import StabilityAnalyzer, StabilityReport
+from thalos_prime.epistemic_v3.transaction import EpistemicTransaction
 from thalos_prime.epistemic_v3.vm import EpistemicProgram, EpistemicVM
 from thalos_prime.epistemic_v3.warrant import Warrant, WarrantAlgebra
 from thalos_prime.epistemic_v3.witness import Witness, WitnessCalculus
@@ -26,6 +27,7 @@ __all__ = [
     "CounterfactualEngine",
     "CounterfactualReport",
     "EpistemicProgram",
+    "EpistemicTransaction",
     "EpistemicVM",
     "StabilityAnalyzer",
     "StabilityReport",

--- a/thalos_prime/epistemic_v3/__init__.py
+++ b/thalos_prime/epistemic_v3/__init__.py
@@ -1,0 +1,32 @@
+"""Thalos Prime epistemic computing layer v3.
+
+This package introduces the Claim IR, Witness Calculus, Warrant Algebra,
+challenge/falsification engine, belief lattice, epistemic VM, and perturbation
+stability analysis. It is designed to sit above the existing transactional
+foundation without coupling the epistemic model to MCP or any model provider.
+"""
+
+from thalos_prime.epistemic_v3.claim_ir import ClaimIR, ClaimCompiler
+from thalos_prime.epistemic_v3.witness import Witness, WitnessCalculus
+from thalos_prime.epistemic_v3.warrant import Warrant, WarrantAlgebra
+from thalos_prime.epistemic_v3.challenge import ChallengePlan, ChallengeEngine
+from thalos_prime.epistemic_v3.lattice import BeliefPosition, BeliefLattice
+from thalos_prime.epistemic_v3.vm import EpistemicProgram, EpistemicVM
+from thalos_prime.epistemic_v3.stability import StabilityReport, StabilityAnalyzer
+
+__all__ = [
+    "BeliefLattice",
+    "BeliefPosition",
+    "ChallengeEngine",
+    "ChallengePlan",
+    "ClaimCompiler",
+    "ClaimIR",
+    "EpistemicProgram",
+    "EpistemicVM",
+    "StabilityAnalyzer",
+    "StabilityReport",
+    "Warrant",
+    "WarrantAlgebra",
+    "Witness",
+    "WitnessCalculus",
+]

--- a/thalos_prime/epistemic_v3/__init__.py
+++ b/thalos_prime/epistemic_v3/__init__.py
@@ -1,18 +1,20 @@
 """Thalos Prime epistemic computing layer v3.
 
 This package introduces the Claim IR, Witness Calculus, Warrant Algebra,
-challenge/falsification engine, belief lattice, epistemic VM, and perturbation
-stability analysis. It is designed to sit above the existing transactional
-foundation without coupling the epistemic model to MCP or any model provider.
+challenge/falsification engine, belief lattice, epistemic VM, perturbation
+stability analysis, and counterfactual decision analysis. It sits above the
+transactional foundation without coupling epistemic computation to MCP or
+any model provider.
 """
 
-from thalos_prime.epistemic_v3.claim_ir import ClaimIR, ClaimCompiler
-from thalos_prime.epistemic_v3.witness import Witness, WitnessCalculus
-from thalos_prime.epistemic_v3.warrant import Warrant, WarrantAlgebra
-from thalos_prime.epistemic_v3.challenge import ChallengePlan, ChallengeEngine
-from thalos_prime.epistemic_v3.lattice import BeliefPosition, BeliefLattice
+from thalos_prime.epistemic_v3.challenge import ChallengeEngine, ChallengePlan
+from thalos_prime.epistemic_v3.claim_ir import ClaimCompiler, ClaimIR
+from thalos_prime.epistemic_v3.counterfactual import CounterfactualEngine, CounterfactualReport
+from thalos_prime.epistemic_v3.lattice import BeliefLattice, BeliefPosition
+from thalos_prime.epistemic_v3.stability import StabilityAnalyzer, StabilityReport
 from thalos_prime.epistemic_v3.vm import EpistemicProgram, EpistemicVM
-from thalos_prime.epistemic_v3.stability import StabilityReport, StabilityAnalyzer
+from thalos_prime.epistemic_v3.warrant import Warrant, WarrantAlgebra
+from thalos_prime.epistemic_v3.witness import Witness, WitnessCalculus
 
 __all__ = [
     "BeliefLattice",
@@ -21,6 +23,8 @@ __all__ = [
     "ChallengePlan",
     "ClaimCompiler",
     "ClaimIR",
+    "CounterfactualEngine",
+    "CounterfactualReport",
     "EpistemicProgram",
     "EpistemicVM",
     "StabilityAnalyzer",

--- a/thalos_prime/epistemic_v3/challenge.py
+++ b/thalos_prime/epistemic_v3/challenge.py
@@ -1,0 +1,179 @@
+"""Falsification shadows and adversarial challenge planning."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Iterable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from thalos_prime.epistemic_v3.claim_ir import ClaimIR, ClaimType
+from thalos_prime.epistemic_v3.warrant import Warrant
+
+
+class ChallengeKind(StrEnum):
+    """Kinds of challenge generated for a claim."""
+
+    COUNTEREVIDENCE = "counterevidence"
+    SOURCE_DEPENDENCE = "source_dependence"
+    TEMPORAL = "temporal"
+    SCOPE = "scope"
+    ALTERNATIVE_EXPLANATION = "alternative_explanation"
+    IDENTITY = "identity"
+    CAUSAL = "causal"
+    MEASUREMENT = "measurement"
+
+
+class ChallengeTask(BaseModel):
+    """A deterministic challenge request that another component can execute."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    task_id: str
+    kind: ChallengeKind
+    question: str
+    target_claim_id: str
+    priority: int = Field(ge=1, le=10)
+    required: bool = True
+
+
+class ChallengePlan(BaseModel):
+    """Complete falsification shadow for one claim."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    plan_id: str
+    claim_id: str
+    tasks: tuple[ChallengeTask, ...]
+    falsification_conditions: tuple[str, ...]
+    generated_by: str = "challenge-engine-v1"
+
+    @property
+    def required_task_count(self) -> int:
+        return sum(1 for task in self.tasks if task.required)
+
+
+@dataclass(frozen=True)
+class ChallengeOutcome:
+    """Result of running a challenge task against existing warrant."""
+
+    task_id: str
+    passed: bool
+    severity: float
+    explanation: str
+
+
+class ChallengeEngine:
+    """Create and score falsification plans without assuming the claim is true."""
+
+    VERSION = "challenge-engine-v1"
+
+    @classmethod
+    def build_plan(cls, claim: ClaimIR) -> ChallengePlan:
+        tasks: list[ChallengeTask] = [
+            cls._task(claim, ChallengeKind.COUNTEREVIDENCE, "What credible evidence would directly contradict this claim?", 10),
+            cls._task(claim, ChallengeKind.SOURCE_DEPENDENCE, "Are the supporting witnesses causally dependent on one another?", 9),
+            cls._task(claim, ChallengeKind.TEMPORAL, "Could the evidence be valid for a different time interval than the claim?", 8),
+            cls._task(claim, ChallengeKind.SCOPE, "Does the evidence support the exact scope, population, quantity, or location asserted?", 8),
+        ]
+        conditions = [
+            "A credible counter-witness directly entailing the negation of the claim.",
+            "The principal supporting witnesses collapse into one causal lineage.",
+            "The evidence is temporally invalid for the claim's stated interval.",
+            "The evidence supports a narrower proposition than the claim being evaluated.",
+        ]
+
+        if claim.claim_type is ClaimType.CAUSAL:
+            tasks.append(cls._task(
+                claim,
+                ChallengeKind.ALTERNATIVE_EXPLANATION,
+                "What plausible competing cause could explain the observed outcome?",
+                10,
+            ))
+            tasks.append(cls._task(
+                claim,
+                ChallengeKind.CAUSAL,
+                "Is temporal order being mistaken for causation, and are confounders controlled?",
+                10,
+            ))
+            conditions.extend([
+                "A competing causal explanation accounts for the outcome at least as well.",
+                "The evidence establishes correlation or sequence but not causal identification.",
+            ])
+        elif claim.claim_type is ClaimType.IDENTITY:
+            tasks.append(cls._task(
+                claim,
+                ChallengeKind.IDENTITY,
+                "Could the evidence refer to a different entity with the same or similar identifier?",
+                10,
+            ))
+            conditions.append("The source identity cannot be uniquely bound to the target entity.")
+        elif claim.claim_type is ClaimType.STATISTICAL:
+            tasks.append(cls._task(
+                claim,
+                ChallengeKind.MEASUREMENT,
+                "Could measurement error, sampling bias, or denominator choice reverse the conclusion?",
+                9,
+            ))
+            conditions.append("A measurement or sampling artifact plausibly explains the observed result.")
+
+        normalized_tasks = tuple(sorted(tasks, key=lambda task: (-task.priority, task.task_id)))
+        payload = {
+            "claim_id": claim.claim_id,
+            "tasks": [task.model_dump(mode="json") for task in normalized_tasks],
+            "conditions": conditions,
+            "version": cls.VERSION,
+        }
+        plan_id = "chlg:" + hashlib.sha256(
+            json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        return ChallengePlan(
+            plan_id=plan_id,
+            claim_id=claim.claim_id,
+            tasks=normalized_tasks,
+            falsification_conditions=tuple(conditions),
+            generated_by=cls.VERSION,
+        )
+
+    @classmethod
+    def assess_warrant(
+        cls,
+        plan: ChallengePlan,
+        warrant: Warrant,
+        *,
+        completed_task_ids: Iterable[str] = (),
+        failed_task_ids: Iterable[str] = (),
+    ) -> tuple[ChallengeOutcome, ...]:
+        completed = set(completed_task_ids)
+        failed = set(failed_task_ids)
+        outcomes: list[ChallengeOutcome] = []
+        for task in plan.tasks:
+            if task.task_id in failed:
+                outcomes.append(ChallengeOutcome(task.task_id, False, 1.0, "Challenge produced a material failure."))
+                continue
+            if task.task_id in completed:
+                outcomes.append(ChallengeOutcome(task.task_id, True, 0.0, "Challenge completed without finding a disqualifying condition."))
+                continue
+            severity = 1.0 - warrant.falsifiability
+            outcomes.append(ChallengeOutcome(
+                task.task_id,
+                False,
+                round(severity, 6),
+                "Challenge remains unresolved; the claim is not fully falsified, but its vulnerability is untested.",
+            ))
+        return tuple(outcomes)
+
+    @classmethod
+    def _task(cls, claim: ClaimIR, kind: ChallengeKind, question: str, priority: int) -> ChallengeTask:
+        raw = f"{cls.VERSION}|{claim.claim_id}|{kind.value}|{question}"
+        task_id = "task:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+        return ChallengeTask(
+            task_id=task_id,
+            kind=kind,
+            question=question,
+            target_claim_id=claim.claim_id,
+            priority=priority,
+        )

--- a/thalos_prime/epistemic_v3/claim_ir.py
+++ b/thalos_prime/epistemic_v3/claim_ir.py
@@ -1,0 +1,199 @@
+"""Claim Intermediate Representation and deterministic claim compilation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ClaimModality(StrEnum):
+    """Epistemic modality assigned during claim compilation."""
+
+    ASSERTION = "assertion"
+    NEGATION = "negation"
+    POSSIBILITY = "possibility"
+    NECESSITY = "necessity"
+    PREDICTION = "prediction"
+    QUESTION = "question"
+    UNKNOWN = "unknown"
+
+
+class ClaimType(StrEnum):
+    """Coarse semantic class used to select verification programs."""
+
+    FACTUAL = "factual"
+    TEMPORAL = "temporal"
+    CAUSAL = "causal"
+    COMPARATIVE = "comparative"
+    IDENTITY = "identity"
+    STATISTICAL = "statistical"
+    LEGAL = "legal"
+    SCIENTIFIC = "scientific"
+    PREDICTIVE = "predictive"
+    NORMATIVE = "normative"
+    UNKNOWN = "unknown"
+
+
+class ClaimIR(BaseModel):
+    """Canonical intermediate representation for an atomic proposition."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    claim_id: str
+    source_text: str
+    canonical_text: str
+    claim_type: ClaimType = ClaimType.UNKNOWN
+    modality: ClaimModality = ClaimModality.UNKNOWN
+    subject: str | None = None
+    predicate: str | None = None
+    object: str | None = None
+    valid_from: str | None = None
+    valid_to: str | None = None
+    qualifiers: tuple[tuple[str, str], ...] = Field(default_factory=tuple)
+    compiler_version: str = "claim-ir-v1"
+
+
+@dataclass(frozen=True)
+class CompilationResult:
+    """Deterministic result of compiling one user statement."""
+
+    claim: ClaimIR
+    warnings: tuple[str, ...] = ()
+
+
+class ClaimCompiler:
+    """Conservative compiler from natural language to Claim IR.
+
+    This is intentionally not a general semantic parser. It provides a stable
+    baseline that preserves uncertainty rather than inventing structure. A
+    model-assisted parser may enrich the IR later, but enriched fields must be
+    explicitly marked as proposals and recompiled through validation.
+    """
+
+    VERSION = "claim-ir-v1"
+
+    _QUESTION_PREFIXES = ("is ", "are ", "was ", "were ", "did ", "does ", "do ", "can ", "could ", "will ")
+    _NEGATION_TOKENS = ("not ", "never ", "no ", "isn't", "wasn't", "didn't", "doesn't", "don't")
+    _CAUSAL_MARKERS = (" caused ", " causes ", " led to ", " resulted in ", " because ", " due to ")
+    _PREDICTIVE_MARKERS = ("will ", "expected to ", "projected to ", "forecast to ")
+    _TEMPORAL_PATTERN = re.compile(r"\b(\d{4}(?:-\d{2}(?:-\d{2})?)?)\b")
+
+    @classmethod
+    def compile(
+        cls,
+        text: str,
+        *,
+        claim_type: ClaimType | None = None,
+        subject: str | None = None,
+        predicate: str | None = None,
+        object: str | None = None,
+        valid_from: str | None = None,
+        valid_to: str | None = None,
+    ) -> CompilationResult:
+        canonical = " ".join(text.replace("\r\n", "\n").replace("\r", "\n").split()).strip()
+        if not canonical:
+            raise ValueError("Claim text must not be empty")
+
+        lowered = canonical.lower()
+        modality = cls._infer_modality(lowered)
+        inferred_type = claim_type or cls._infer_type(lowered, modality)
+        inferred_from, inferred_to = cls._infer_temporal_scope(canonical)
+
+        start = valid_from if valid_from is not None else inferred_from
+        end = valid_to if valid_to is not None else inferred_to
+        qualifiers: list[tuple[str, str]] = []
+        if start:
+            qualifiers.append(("valid_from", start))
+        if end:
+            qualifiers.append(("valid_to", end))
+
+        identity = {
+            "canonical_text": canonical,
+            "claim_type": inferred_type.value,
+            "modality": modality.value,
+            "subject": subject,
+            "predicate": predicate,
+            "object": object,
+            "valid_from": start,
+            "valid_to": end,
+            "qualifiers": qualifiers,
+            "compiler_version": cls.VERSION,
+        }
+        claim_id = "clmir:" + hashlib.sha256(
+            json.dumps(identity, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+
+        warnings: list[str] = []
+        if modality is ClaimModality.UNKNOWN:
+            warnings.append("modality could not be inferred; treating as unknown")
+        if inferred_type is ClaimType.UNKNOWN:
+            warnings.append("claim type could not be inferred; verification planning must remain conservative")
+        if subject is None or predicate is None or object is None:
+            warnings.append("semantic slots are incomplete; no world-state interpretation is assumed")
+
+        return CompilationResult(
+            claim=ClaimIR(
+                claim_id=claim_id,
+                source_text=text,
+                canonical_text=canonical,
+                claim_type=inferred_type,
+                modality=modality,
+                subject=subject,
+                predicate=predicate,
+                object=object,
+                valid_from=start,
+                valid_to=end,
+                qualifiers=tuple(qualifiers),
+                compiler_version=cls.VERSION,
+            ),
+            warnings=tuple(warnings),
+        )
+
+    @classmethod
+    def _infer_modality(cls, lowered: str) -> ClaimModality:
+        if lowered.endswith("?") or lowered.startswith(cls._QUESTION_PREFIXES):
+            return ClaimModality.QUESTION
+        if any(marker in lowered for marker in cls._PREDICTIVE_MARKERS):
+            return ClaimModality.PREDICTION
+        if any(token in lowered for token in cls._NEGATION_TOKENS):
+            return ClaimModality.NEGATION
+        return ClaimModality.ASSERTION
+
+    @classmethod
+    def _infer_type(cls, lowered: str, modality: ClaimModality) -> ClaimType:
+        if modality is ClaimModality.PREDICTION:
+            return ClaimType.PREDICTIVE
+        if any(marker in lowered for marker in cls._CAUSAL_MARKERS):
+            return ClaimType.CAUSAL
+        if " statistically " in f" {lowered} ":
+            return ClaimType.STATISTICAL
+        if any(token in lowered for token in ("legal", "lawful", "unlawful", "court", "statute")):
+            return ClaimType.LEGAL
+        if any(token in lowered for token in ("study", "experiment", "scientific", "clinical")):
+            return ClaimType.SCIENTIFIC
+        if cls._TEMPORAL_PATTERN.search(lowered):
+            return ClaimType.TEMPORAL
+        return ClaimType.FACTUAL
+
+    @classmethod
+    def _infer_temporal_scope(cls, text: str) -> tuple[str | None, str | None]:
+        years = cls._TEMPORAL_PATTERN.findall(text)
+        if not years:
+            return None, None
+        if len(years) == 1:
+            return years[0], years[0]
+        return years[0], years[-1]
+
+
+# Small helper used by external callers that need deterministic serialization.
+def claim_fingerprint(claim: ClaimIR) -> str:
+    payload: dict[str, Any] = claim.model_dump(mode="json")
+    return hashlib.sha256(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()

--- a/thalos_prime/epistemic_v3/counterfactual.py
+++ b/thalos_prime/epistemic_v3/counterfactual.py
@@ -1,0 +1,92 @@
+"""Counterfactual evidence analysis and decision-flip discovery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Callable, Sequence
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CounterfactualCase(BaseModel):
+    """One minimal perturbation that changes the decision."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    removed_evidence: tuple[str, ...]
+    remaining_evidence: tuple[str, ...]
+    resulting_decision: str
+    flip: bool
+    minimal: bool
+
+
+class CounterfactualReport(BaseModel):
+    """Decision sensitivity surface for a fixed evidence set."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    baseline_decision: str
+    evidence_count: int = Field(ge=0)
+    cases_examined: int = Field(ge=0)
+    flip_cases: tuple[CounterfactualCase, ...]
+    minimal_flip_cases: tuple[CounterfactualCase, ...]
+    critical_evidence: tuple[str, ...]
+    robust_evidence: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CounterfactualEngine:
+    """Search the local evidence neighborhood for decision-flipping changes."""
+
+    max_removal_order: int = 2
+
+    def analyze(
+        self,
+        *,
+        evidence_ids: Sequence[str],
+        baseline_decision: str,
+        decide: Callable[[tuple[str, ...]], str],
+    ) -> CounterfactualReport:
+        base = tuple(sorted(set(evidence_ids)))
+        examined = 0
+        flip_cases: list[CounterfactualCase] = []
+        for order in range(1, min(self.max_removal_order, len(base)) + 1):
+            for removed in combinations(base, order):
+                examined += 1
+                removed_set = set(removed)
+                remaining = tuple(item for item in base if item not in removed_set)
+                decision = decide(remaining)
+                flip = decision != baseline_decision
+                case = CounterfactualCase(
+                    removed_evidence=removed,
+                    remaining_evidence=remaining,
+                    resulting_decision=decision,
+                    flip=flip,
+                    minimal=False,
+                )
+                if flip:
+                    flip_cases.append(case)
+
+        minimal: list[CounterfactualCase] = []
+        for case in flip_cases:
+            if case.removed_evidence and not any(
+                set(other.removed_evidence).issubset(set(case.removed_evidence))
+                and len(other.removed_evidence) < len(case.removed_evidence)
+                for other in flip_cases
+            ):
+                minimal.append(case.model_copy(update={"minimal": True}))
+
+        critical: set[str] = set()
+        for case in minimal:
+            critical.update(case.removed_evidence)
+        robust = set(base) - critical
+        return CounterfactualReport(
+            baseline_decision=baseline_decision,
+            evidence_count=len(base),
+            cases_examined=examined,
+            flip_cases=tuple(flip_cases),
+            minimal_flip_cases=tuple(minimal),
+            critical_evidence=tuple(sorted(critical)),
+            robust_evidence=tuple(sorted(robust)),
+        )

--- a/thalos_prime/epistemic_v3/decision.py
+++ b/thalos_prime/epistemic_v3/decision.py
@@ -1,0 +1,137 @@
+"""Policy-driven decision compilation for Thalos Prime epistemic transactions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from thalos_prime.epistemic_v3.counterfactual import CounterfactualReport
+from thalos_prime.epistemic_v3.lattice import BeliefPosition, DecisionState, InformationState
+from thalos_prime.epistemic_v3.stability import StabilityReport
+
+
+class DecisionReason(StrEnum):
+    """Explicit reason codes for a compiled epistemic decision."""
+
+    SUPPORT_SUFFICIENT = "support_sufficient"
+    SUPPORT_INSUFFICIENT = "support_insufficient"
+    CONTRADICTION_PRESENT = "contradiction_present"
+    CHALLENGES_UNRESOLVED = "challenges_unresolved"
+    STABILITY_LOW = "stability_low"
+    CRITICAL_EVIDENCE = "critical_evidence"
+    STABLE_AND_REDUNDANT = "stable_and_redundant"
+
+
+class DecisionArtifact(BaseModel):
+    """Auditable policy result derived from a belief position and sensitivity analyses."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    decision_id: str
+    claim_id: str
+    input_decision: DecisionState
+    final_decision: DecisionState
+    reasons: tuple[DecisionReason, ...]
+    stability_score: float = Field(ge=0.0, le=1.0)
+    reversibility_score: float = Field(ge=0.0, le=1.0)
+    critical_evidence_count: int = Field(ge=0)
+    minimum_flip_order: int | None = Field(default=None, ge=1)
+    safe_to_state_as_fact: bool
+    compiler_version: str = "decision-compiler-v1"
+
+
+class DecisionCompiler:
+    """Compile a final policy decision without changing the underlying evidence."""
+
+    VERSION = "decision-compiler-v1"
+
+    def __init__(
+        self,
+        *,
+        minimum_stability: float = 0.75,
+        stable_stability: float = 0.90,
+        max_safe_flip_order: int = 1,
+    ) -> None:
+        self.minimum_stability = minimum_stability
+        self.stable_stability = stable_stability
+        self.max_safe_flip_order = max_safe_flip_order
+
+    def compile(
+        self,
+        *,
+        belief: BeliefPosition,
+        stability: StabilityReport,
+        counterfactual: CounterfactualReport,
+    ) -> DecisionArtifact:
+        reasons: list[DecisionReason] = []
+        decision = belief.decision
+
+        if belief.information_state is InformationState.BOTH or belief.contradiction_strength > 0.0:
+            decision = DecisionState.DISPUTED
+            reasons.append(DecisionReason.CONTRADICTION_PRESENT)
+
+        if belief.unresolved_challenges > 0:
+            if decision is DecisionState.ACCEPTED:
+                decision = DecisionState.PROVISIONAL
+            reasons.append(DecisionReason.CHALLENGES_UNRESOLVED)
+
+        if stability.stability_score < self.minimum_stability:
+            if decision is DecisionState.ACCEPTED:
+                decision = DecisionState.PROVISIONAL
+            reasons.append(DecisionReason.STABILITY_LOW)
+        elif stability.stability_score >= self.stable_stability:
+            reasons.append(DecisionReason.STABLE_AND_REDUNDANT)
+
+        critical = len(counterfactual.critical_evidence)
+        minimum_flip_order = min(
+            (len(case.removed_evidence) for case in counterfactual.minimal_flip_cases),
+            default=None,
+        )
+        if minimum_flip_order is not None and minimum_flip_order <= self.max_safe_flip_order:
+            if decision is DecisionState.ACCEPTED:
+                decision = DecisionState.PROVISIONAL
+            reasons.append(DecisionReason.CRITICAL_EVIDENCE)
+
+        if decision in {DecisionState.ACCEPTED, DecisionState.HISTORICAL_ACCEPTED}:
+            reasons.append(DecisionReason.SUPPORT_SUFFICIENT)
+        elif decision in {DecisionState.PENDING, DecisionState.REJECTED}:
+            reasons.append(DecisionReason.SUPPORT_INSUFFICIENT)
+
+        safe_to_state_as_fact = (
+            decision is DecisionState.ACCEPTED
+            and belief.information_state is InformationState.SUPPORT_ONLY
+            and belief.unresolved_challenges == 0
+            and stability.stability_score >= self.stable_stability
+            and (minimum_flip_order is None or minimum_flip_order > self.max_safe_flip_order)
+        )
+
+        identity = {
+            "claim_id": belief.claim_id,
+            "input_decision": belief.decision.value,
+            "final_decision": decision.value,
+            "reasons": [reason.value for reason in reasons],
+            "stability_score": stability.stability_score,
+            "reversibility_score": stability.reversibility_score,
+            "critical_evidence_count": critical,
+            "minimum_flip_order": minimum_flip_order,
+            "safe_to_state_as_fact": safe_to_state_as_fact,
+            "compiler_version": self.VERSION,
+        }
+        digest = hashlib.sha256(
+            json.dumps(identity, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        return DecisionArtifact(
+            decision_id=f"dec:{digest}",
+            claim_id=belief.claim_id,
+            input_decision=belief.decision,
+            final_decision=decision,
+            reasons=tuple(dict.fromkeys(reasons)),
+            stability_score=stability.stability_score,
+            reversibility_score=stability.reversibility_score,
+            critical_evidence_count=critical,
+            minimum_flip_order=minimum_flip_order,
+            safe_to_state_as_fact=safe_to_state_as_fact,
+        )

--- a/thalos_prime/epistemic_v3/lattice.py
+++ b/thalos_prime/epistemic_v3/lattice.py
@@ -1,0 +1,163 @@
+"""Multi-axis belief lattice and decision classification."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from thalos_prime.epistemic_v3.warrant import Warrant
+
+
+class InformationState(StrEnum):
+    """Information completeness relative to support and contradiction."""
+
+    UNKNOWN = "unknown"
+    SUPPORT_ONLY = "support_only"
+    CONTRADICTION_ONLY = "contradiction_only"
+    BOTH = "both"
+
+
+class StabilityState(StrEnum):
+    """Sensitivity of a decision to removal or perturbation of evidence."""
+
+    UNKNOWN = "unknown"
+    FRAGILE = "fragile"
+    MODERATE = "moderate"
+    STABLE = "stable"
+
+
+class TemporalState(StrEnum):
+    """Temporal applicability of a claim."""
+
+    UNSCOPED = "unscoped"
+    CURRENT = "current"
+    HISTORICAL = "historical"
+    EXPIRED = "expired"
+    CONFLICTED = "conflicted"
+
+
+class DecisionState(StrEnum):
+    """Policy decision independent of world-truth semantics."""
+
+    PENDING = "pending"
+    PROVISIONAL = "provisional"
+    ACCEPTED = "accepted"
+    DISPUTED = "disputed"
+    REJECTED = "rejected"
+    HISTORICAL_ACCEPTED = "historical_accepted"
+
+
+class BeliefPosition(BaseModel):
+    """A point in the multidimensional belief lattice."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    claim_id: str
+    information_state: InformationState
+    support_strength: float = Field(ge=0.0, le=1.0)
+    contradiction_strength: float = Field(ge=0.0, le=1.0)
+    independence: float = Field(ge=0.0, le=1.0)
+    stability: StabilityState
+    temporal: TemporalState
+    decision: DecisionState
+    reversibility: float = Field(ge=0.0, le=1.0)
+    unresolved_challenges: int = Field(ge=0)
+
+    @property
+    def epistemically_safe_to_state_as_fact(self) -> bool:
+        return (
+            self.decision is DecisionState.ACCEPTED
+            and self.information_state is InformationState.SUPPORT_ONLY
+            and self.stability is StabilityState.STABLE
+            and self.unresolved_challenges == 0
+        )
+
+
+@dataclass(frozen=True)
+class LatticeThresholds:
+    """Explicit policy thresholds for classification."""
+
+    accept_support: float = 0.80
+    provisional_support: float = 0.55
+    dispute_contradiction: float = 0.55
+    stable_support: float = 0.80
+    moderate_support: float = 0.55
+    low_reversibility: float = 0.30
+
+
+class BeliefLattice:
+    """Classify claims without collapsing epistemic dimensions into one score."""
+
+    def __init__(self, thresholds: LatticeThresholds | None = None) -> None:
+        self.thresholds = thresholds or LatticeThresholds()
+
+    def classify(
+        self,
+        *,
+        claim_id: str,
+        warrant: Warrant,
+        challenge_count: int,
+        resolved_challenge_count: int,
+        failed_challenge_count: int,
+        temporal: TemporalState = TemporalState.UNSCOPED,
+        stability: StabilityState | None = None,
+    ) -> BeliefPosition:
+        if warrant.support > 0 and warrant.contradiction > 0:
+            information = InformationState.BOTH
+        elif warrant.support > 0:
+            information = InformationState.SUPPORT_ONLY
+        elif warrant.contradiction > 0:
+            information = InformationState.CONTRADICTION_ONLY
+        else:
+            information = InformationState.UNKNOWN
+
+        if stability is None:
+            stability = self._infer_stability(warrant)
+
+        unresolved = max(0, challenge_count - resolved_challenge_count - failed_challenge_count)
+        if information is InformationState.BOTH or warrant.contradiction >= self.thresholds.dispute_contradiction:
+            decision = DecisionState.DISPUTED
+        elif warrant.support >= self.thresholds.accept_support and failed_challenge_count == 0 and unresolved == 0:
+            decision = DecisionState.ACCEPTED
+        elif warrant.support >= self.thresholds.provisional_support:
+            decision = DecisionState.PROVISIONAL
+        else:
+            decision = DecisionState.PENDING
+
+        if temporal is TemporalState.EXPIRED and decision is DecisionState.ACCEPTED:
+            decision = DecisionState.HISTORICAL_ACCEPTED
+
+        reversibility = self._reversibility(warrant, stability, unresolved)
+        return BeliefPosition(
+            claim_id=claim_id,
+            information_state=information,
+            support_strength=round(warrant.support, 6),
+            contradiction_strength=round(warrant.contradiction, 6),
+            independence=round(warrant.independence, 6),
+            stability=stability,
+            temporal=temporal,
+            decision=decision,
+            reversibility=round(reversibility, 6),
+            unresolved_challenges=unresolved,
+        )
+
+    def _infer_stability(self, warrant: Warrant) -> StabilityState:
+        support = warrant.usable_support
+        if support >= self.thresholds.stable_support and warrant.independence >= self.thresholds.stable_support:
+            return StabilityState.STABLE
+        if support >= self.thresholds.moderate_support:
+            return StabilityState.MODERATE
+        return StabilityState.FRAGILE
+
+    @staticmethod
+    def _reversibility(warrant: Warrant, stability: StabilityState, unresolved: int) -> float:
+        stability_penalty = {
+            StabilityState.STABLE: 0.15,
+            StabilityState.MODERATE: 0.45,
+            StabilityState.FRAGILE: 0.80,
+            StabilityState.UNKNOWN: 0.95,
+        }[stability]
+        challenge_penalty = min(0.50, unresolved * 0.10)
+        return max(0.0, min(1.0, stability_penalty + challenge_penalty + (1.0 - warrant.independence) * 0.25))

--- a/thalos_prime/epistemic_v3/stability.py
+++ b/thalos_prime/epistemic_v3/stability.py
@@ -1,0 +1,78 @@
+"""Perturbation stability and reversibility analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Callable, Iterable, Sequence
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class StabilityReport(BaseModel):
+    """Decision stability under controlled evidence perturbations."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    baseline_decision: str
+    perturbation_count: int = Field(ge=0)
+    changed_decision_count: int = Field(ge=0)
+    stability_score: float = Field(ge=0.0, le=1.0)
+    reversibility_score: float = Field(ge=0.0, le=1.0)
+    perturbation_labels: tuple[str, ...] = ()
+    changed_labels: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class Perturbation:
+    """Named deterministic change to an evidence set."""
+
+    label: str
+    evidence_ids: tuple[str, ...]
+
+
+class StabilityAnalyzer:
+    """Measure how easily a conclusion changes under valid perturbations."""
+
+    def analyze(
+        self,
+        *,
+        evidence_ids: Sequence[str],
+        baseline_decision: str,
+        decide: Callable[[tuple[str, ...]], str],
+        max_removals: int = 1,
+    ) -> StabilityReport:
+        base = tuple(sorted(set(evidence_ids)))
+        perturbations = self._build_perturbations(base, max_removals=max_removals)
+        changed: list[str] = []
+        for perturbation in perturbations:
+            decision = decide(perturbation.evidence_ids)
+            if decision != baseline_decision:
+                changed.append(perturbation.label)
+        count = len(perturbations)
+        changed_count = len(changed)
+        stability = 1.0 if count == 0 else 1.0 - (changed_count / count)
+        reversibility = 1.0 - stability
+        return StabilityReport(
+            baseline_decision=baseline_decision,
+            perturbation_count=count,
+            changed_decision_count=changed_count,
+            stability_score=round(stability, 6),
+            reversibility_score=round(reversibility, 6),
+            perturbation_labels=tuple(p.label for p in perturbations),
+            changed_labels=tuple(changed),
+        )
+
+    @staticmethod
+    def _build_perturbations(evidence_ids: tuple[str, ...], max_removals: int) -> tuple[Perturbation, ...]:
+        if max_removals < 1:
+            return ()
+        perturbations: list[Perturbation] = []
+        for size in range(1, min(max_removals, len(evidence_ids)) + 1):
+            for subset in combinations(evidence_ids, size):
+                removed = set(subset)
+                remaining = tuple(item for item in evidence_ids if item not in removed)
+                label = "remove:" + ",".join(subset)
+                perturbations.append(Perturbation(label=label, evidence_ids=remaining))
+        perturbations.append(Perturbation(label="reorder:reverse", evidence_ids=tuple(reversed(evidence_ids))))
+        return tuple(perturbations)

--- a/thalos_prime/epistemic_v3/transaction.py
+++ b/thalos_prime/epistemic_v3/transaction.py
@@ -1,0 +1,120 @@
+"""Immutable epistemic transaction aggregate for Thalos Prime v3.
+
+The transaction is the unit that binds the complete computational state of an
+investigation before any durable belief commit occurs. It is intentionally
+model-provider and MCP independent.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from thalos_prime.epistemic_v3.claim_ir import ClaimIR
+from thalos_prime.epistemic_v3.counterfactual import CounterfactualReport
+from thalos_prime.epistemic_v3.lattice import BeliefPosition
+from thalos_prime.epistemic_v3.stability import StabilityReport
+from thalos_prime.epistemic_v3.warrant import Warrant
+from thalos_prime.epistemic_v3.witness import WitnessAnalysis
+
+
+class EpistemicTransaction(BaseModel):
+    """Content-addressed aggregate representing one epistemic computation."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    transaction_id: str
+    claim: ClaimIR
+    challenge_plan_id: str
+    witness_analysis: Mapping[str, Any]
+    warrant: Warrant
+    belief_position: BeliefPosition
+    stability_report: StabilityReport
+    counterfactual_report: CounterfactualReport
+    source_snapshot_id: str | None = None
+    run_id: str | None = None
+    proof_bundle_id: str | None = None
+    compiler_version: str = "epistemic-transaction-v1"
+    committed_event_id: str | None = None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        claim: ClaimIR,
+        challenge_plan_id: str,
+        witness_analysis: WitnessAnalysis | Mapping[str, Any],
+        warrant: Warrant,
+        belief_position: BeliefPosition,
+        stability_report: StabilityReport,
+        counterfactual_report: CounterfactualReport,
+        source_snapshot_id: str | None = None,
+        run_id: str | None = None,
+        proof_bundle_id: str | None = None,
+    ) -> "EpistemicTransaction":
+        if isinstance(witness_analysis, WitnessAnalysis):
+            witness_payload: Mapping[str, Any] = {
+                "eligible_witness_ids": witness_analysis.eligible_witness_ids,
+                "independent_groups": witness_analysis.independent_groups,
+                "root_lineages": witness_analysis.root_lineages,
+                "independence_score": witness_analysis.independence_score,
+                "correlation_penalty": witness_analysis.correlation_penalty,
+            }
+        else:
+            witness_payload = dict(witness_analysis)
+
+        payload = {
+            "claim": claim.model_dump(mode="json"),
+            "challenge_plan_id": challenge_plan_id,
+            "witness_analysis": witness_payload,
+            "warrant": warrant.model_dump(mode="json"),
+            "belief_position": belief_position.model_dump(mode="json"),
+            "stability_report": stability_report.model_dump(mode="json"),
+            "counterfactual_report": counterfactual_report.model_dump(mode="json"),
+            "source_snapshot_id": source_snapshot_id,
+            "run_id": run_id,
+            "proof_bundle_id": proof_bundle_id,
+            "compiler_version": "epistemic-transaction-v1",
+        }
+        digest = hashlib.sha256(
+            json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        return cls(
+            transaction_id=f"txn:{digest}",
+            claim=claim,
+            challenge_plan_id=challenge_plan_id,
+            witness_analysis=witness_payload,
+            warrant=warrant,
+            belief_position=belief_position,
+            stability_report=stability_report,
+            counterfactual_report=counterfactual_report,
+            source_snapshot_id=source_snapshot_id,
+            run_id=run_id,
+            proof_bundle_id=proof_bundle_id,
+        )
+
+    @property
+    def fingerprint(self) -> str:
+        """Return a stable fingerprint of the complete transaction state."""
+        payload = self.model_dump(mode="json", exclude={"committed_event_id"})
+        return hashlib.sha256(
+            json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+
+    @property
+    def ready_for_commit(self) -> bool:
+        """Whether the computation is structurally complete enough for policy review."""
+        return (
+            self.belief_position.unresolved_challenges == 0
+            and self.stability_report.baseline_decision == self.belief_position.decision.value
+            and self.counterfactual_report.baseline_decision == self.belief_position.decision.value
+        )
+
+    def bind_commit(self, event_id: str) -> "EpistemicTransaction":
+        """Return a new transaction bound to the durable commit event."""
+        if not event_id:
+            raise ValueError("event_id must not be empty")
+        return self.model_copy(update={"committed_event_id": event_id})

--- a/thalos_prime/epistemic_v3/transaction.py
+++ b/thalos_prime/epistemic_v3/transaction.py
@@ -11,18 +11,19 @@ import hashlib
 import json
 from typing import Any, Mapping
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 
 from thalos_prime.epistemic_v3.claim_ir import ClaimIR
 from thalos_prime.epistemic_v3.counterfactual import CounterfactualReport
-from thalos_prime.epistemic_v3.lattice import BeliefPosition
+from thalos_prime.epistemic_v3.decision import DecisionArtifact
+from thalos_prime.epistemic_v3.lattice import BeliefPosition, DecisionState
 from thalos_prime.epistemic_v3.stability import StabilityReport
 from thalos_prime.epistemic_v3.warrant import Warrant
 from thalos_prime.epistemic_v3.witness import WitnessAnalysis
 
 
 class EpistemicTransaction(BaseModel):
-    """Content-addressed aggregate representing one epistemic computation."""
+    """Content-addressed aggregate representing one complete epistemic computation."""
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -32,12 +33,13 @@ class EpistemicTransaction(BaseModel):
     witness_analysis: Mapping[str, Any]
     warrant: Warrant
     belief_position: BeliefPosition
+    decision_artifact: DecisionArtifact
     stability_report: StabilityReport
     counterfactual_report: CounterfactualReport
     source_snapshot_id: str | None = None
     run_id: str | None = None
     proof_bundle_id: str | None = None
-    compiler_version: str = "epistemic-transaction-v1"
+    compiler_version: str = "epistemic-transaction-v2"
     committed_event_id: str | None = None
 
     @classmethod
@@ -49,12 +51,22 @@ class EpistemicTransaction(BaseModel):
         witness_analysis: WitnessAnalysis | Mapping[str, Any],
         warrant: Warrant,
         belief_position: BeliefPosition,
+        decision_artifact: DecisionArtifact,
         stability_report: StabilityReport,
         counterfactual_report: CounterfactualReport,
         source_snapshot_id: str | None = None,
         run_id: str | None = None,
         proof_bundle_id: str | None = None,
     ) -> "EpistemicTransaction":
+        if decision_artifact.claim_id != claim.claim_id:
+            raise ValueError("decision artifact does not belong to claim")
+        if decision_artifact.input_decision is not belief_position.decision:
+            raise ValueError("decision artifact input decision does not match belief position")
+        if stability_report.baseline_decision != belief_position.decision.value:
+            raise ValueError("stability baseline does not match belief position decision")
+        if counterfactual_report.baseline_decision != belief_position.decision.value:
+            raise ValueError("counterfactual baseline does not match belief position decision")
+
         if isinstance(witness_analysis, WitnessAnalysis):
             witness_payload: Mapping[str, Any] = {
                 "eligible_witness_ids": witness_analysis.eligible_witness_ids,
@@ -72,12 +84,13 @@ class EpistemicTransaction(BaseModel):
             "witness_analysis": witness_payload,
             "warrant": warrant.model_dump(mode="json"),
             "belief_position": belief_position.model_dump(mode="json"),
+            "decision_artifact": decision_artifact.model_dump(mode="json"),
             "stability_report": stability_report.model_dump(mode="json"),
             "counterfactual_report": counterfactual_report.model_dump(mode="json"),
             "source_snapshot_id": source_snapshot_id,
             "run_id": run_id,
             "proof_bundle_id": proof_bundle_id,
-            "compiler_version": "epistemic-transaction-v1",
+            "compiler_version": "epistemic-transaction-v2",
         }
         digest = hashlib.sha256(
             json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
@@ -89,6 +102,7 @@ class EpistemicTransaction(BaseModel):
             witness_analysis=witness_payload,
             warrant=warrant,
             belief_position=belief_position,
+            decision_artifact=decision_artifact,
             stability_report=stability_report,
             counterfactual_report=counterfactual_report,
             source_snapshot_id=source_snapshot_id,
@@ -98,7 +112,7 @@ class EpistemicTransaction(BaseModel):
 
     @property
     def fingerprint(self) -> str:
-        """Return a stable fingerprint of the complete transaction state."""
+        """Return a stable fingerprint of the complete computational transaction."""
         payload = self.model_dump(mode="json", exclude={"committed_event_id"})
         return hashlib.sha256(
             json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
@@ -109,6 +123,8 @@ class EpistemicTransaction(BaseModel):
         """Whether the computation is structurally complete enough for policy review."""
         return (
             self.belief_position.unresolved_challenges == 0
+            and self.decision_artifact.final_decision in {DecisionState.ACCEPTED, DecisionState.HISTORICAL_ACCEPTED}
+            and self.decision_artifact.final_decision is self.belief_position.decision
             and self.stability_report.baseline_decision == self.belief_position.decision.value
             and self.counterfactual_report.baseline_decision == self.belief_position.decision.value
         )

--- a/thalos_prime/epistemic_v3/vm.py
+++ b/thalos_prime/epistemic_v3/vm.py
@@ -1,0 +1,162 @@
+"""Deterministic Epistemic VM for replayable verification workflows."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from enum import StrEnum
+from typing import Any, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from thalos_prime.epistemic_v3.challenge import ChallengeEngine
+from thalos_prime.epistemic_v3.claim_ir import ClaimCompiler, ClaimIR
+from thalos_prime.epistemic_v3.lattice import BeliefLattice, BeliefPosition
+from thalos_prime.epistemic_v3.warrant import Warrant
+
+
+class Opcode(StrEnum):
+    """Pure instructions supported by the baseline epistemic VM."""
+
+    COMPILE_CLAIM = "COMPILE_CLAIM"
+    BUILD_CHALLENGE_PLAN = "BUILD_CHALLENGE_PLAN"
+    CLASSIFY_BELIEF = "CLASSIFY_BELIEF"
+    EMIT_RESULT = "EMIT_RESULT"
+
+
+class Instruction(BaseModel):
+    """One immutable VM instruction."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    opcode: Opcode
+    args: Mapping[str, Any] = Field(default_factory=dict)
+
+
+class EpistemicProgram(BaseModel):
+    """Versioned program executed by the deterministic VM."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    program_id: str
+    instructions: tuple[Instruction, ...]
+    compiler_version: str = "epistemic-vm-v1"
+
+    @classmethod
+    def create(cls, instructions: tuple[Instruction, ...]) -> "EpistemicProgram":
+        payload = [instruction.model_dump(mode="json") for instruction in instructions]
+        program_id = "prog:" + hashlib.sha256(
+            json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        return cls(program_id=program_id, instructions=instructions)
+
+
+class VMState(BaseModel):
+    """Serializable machine state, suitable for replay and checkpointing."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    instruction_pointer: int = 0
+    registers: Mapping[str, Any] = Field(default_factory=dict)
+    halted: bool = False
+
+
+class VMResult(BaseModel):
+    """Deterministic execution output."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    program_id: str
+    state: VMState
+    claim: ClaimIR | None = None
+    belief: BeliefPosition | None = None
+    challenge_plan_id: str | None = None
+    execution_fingerprint: str
+
+
+class EpistemicVM:
+    """Execute pure epistemic instructions without network or model calls."""
+
+    VERSION = "epistemic-vm-v1"
+
+    def execute(self, program: EpistemicProgram, inputs: Mapping[str, Any]) -> VMResult:
+        registers: dict[str, Any] = dict(inputs)
+        state = VMState(registers=registers)
+        claim: ClaimIR | None = None
+        belief: BeliefPosition | None = None
+        challenge_plan_id: str | None = None
+        ip = 0
+
+        while ip < len(program.instructions):
+            instruction = program.instructions[ip]
+            if instruction.opcode is Opcode.COMPILE_CLAIM:
+                result = ClaimCompiler.compile(
+                    str(registers["query"]),
+                    subject=instruction.args.get("subject"),
+                    predicate=instruction.args.get("predicate"),
+                    object=instruction.args.get("object"),
+                    valid_from=instruction.args.get("valid_from"),
+                    valid_to=instruction.args.get("valid_to"),
+                )
+                claim = result.claim
+                registers["claim"] = claim
+                registers["compiler_warnings"] = result.warnings
+            elif instruction.opcode is Opcode.BUILD_CHALLENGE_PLAN:
+                if claim is None:
+                    raise RuntimeError("BUILD_CHALLENGE_PLAN requires a compiled claim")
+                plan = ChallengeEngine.build_plan(claim)
+                registers["challenge_plan"] = plan
+                challenge_plan_id = plan.plan_id
+            elif instruction.opcode is Opcode.CLASSIFY_BELIEF:
+                if claim is None:
+                    raise RuntimeError("CLASSIFY_BELIEF requires a compiled claim")
+                warrant = registers.get("warrant")
+                if not isinstance(warrant, Warrant):
+                    raise TypeError("CLASSIFY_BELIEF requires a Warrant in VM inputs")
+                lattice = BeliefLattice()
+                belief = lattice.classify(
+                    claim_id=claim.claim_id,
+                    warrant=warrant,
+                    challenge_count=int(registers.get("challenge_count", 0)),
+                    resolved_challenge_count=int(registers.get("resolved_challenge_count", 0)),
+                    failed_challenge_count=int(registers.get("failed_challenge_count", 0)),
+                )
+                registers["belief"] = belief
+            elif instruction.opcode is Opcode.EMIT_RESULT:
+                registers["result"] = {
+                    "claim_id": claim.claim_id if claim else None,
+                    "belief": belief.model_dump(mode="json") if belief else None,
+                }
+            else:
+                raise RuntimeError(f"Unsupported opcode: {instruction.opcode}")
+            ip += 1
+
+        state = VMState(instruction_pointer=ip, registers=registers, halted=True)
+        fingerprint_payload = {
+            "program_id": program.program_id,
+            "state": state.model_dump(mode="json"),
+            "claim_id": claim.claim_id if claim else None,
+            "belief": belief.model_dump(mode="json") if belief else None,
+            "challenge_plan_id": challenge_plan_id,
+        }
+        execution_fingerprint = hashlib.sha256(
+            json.dumps(fingerprint_payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        return VMResult(
+            program_id=program.program_id,
+            state=state,
+            claim=claim,
+            belief=belief,
+            challenge_plan_id=challenge_plan_id,
+            execution_fingerprint=execution_fingerprint,
+        )
+
+
+DEFAULT_INVESTIGATION_PROGRAM = EpistemicProgram.create(
+    (
+        Instruction(opcode=Opcode.COMPILE_CLAIM),
+        Instruction(opcode=Opcode.BUILD_CHALLENGE_PLAN),
+        Instruction(opcode=Opcode.CLASSIFY_BELIEF),
+        Instruction(opcode=Opcode.EMIT_RESULT),
+    )
+)

--- a/thalos_prime/epistemic_v3/warrant.py
+++ b/thalos_prime/epistemic_v3/warrant.py
@@ -1,0 +1,218 @@
+"""Warrant Algebra and epistemic-conservation transfer rules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from math import prod
+from typing import Iterable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class WarrantOperation(StrEnum):
+    """Explicit transformation type for epistemic warrant."""
+
+    COPY = "copy"
+    PARAPHRASE = "paraphrase"
+    SUMMARIZE = "summarize"
+    DEDUCE = "deduce"
+    CORROBORATE = "corroborate"
+    CONTRADICT = "contradict"
+    SPECULATE = "speculate"
+
+
+class Warrant(BaseModel):
+    """Multi-dimensional warrant state; never reduced to one confidence scalar."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    support: float = Field(ge=0.0, le=1.0)
+    contradiction: float = Field(ge=0.0, le=1.0)
+    entailment: float = Field(ge=0.0, le=1.0)
+    temporal_validity: float = Field(ge=0.0, le=1.0)
+    scope_validity: float = Field(ge=0.0, le=1.0)
+    independence: float = Field(ge=0.0, le=1.0)
+    provenance_integrity: float = Field(ge=0.0, le=1.0)
+    reproducibility: float = Field(ge=0.0, le=1.0)
+    falsifiability: float = Field(ge=0.0, le=1.0)
+
+    @property
+    def usable_support(self) -> float:
+        """Support usable for a decision without hiding individual dimensions."""
+        return min(
+            self.support,
+            self.entailment,
+            self.temporal_validity,
+            self.scope_validity,
+            self.independence,
+            self.provenance_integrity,
+        )
+
+    @property
+    def conflict_index(self) -> float:
+        """Explicit conflict measure; support is never silently canceled."""
+        return min(1.0, self.contradiction)
+
+
+@dataclass(frozen=True)
+class WarrantTransfer:
+    """Audit record for an epistemic transformation."""
+
+    operation: WarrantOperation
+    input_warrant: Warrant
+    output_warrant: Warrant
+    rule_id: str
+    explanation: str
+
+    @property
+    def conserved(self) -> bool:
+        """Whether the transfer obeyed the no-free-warrant invariant."""
+        return self.output_warrant.usable_support <= self.input_warrant.usable_support + 1e-12
+
+
+class WarrantAlgebra:
+    """Apply explicit, replayable warrant transformations.
+
+    The central invariant is epistemic conservation: a transformation cannot
+    create stronger usable support without an explicit operation that introduces
+    new independent evidence or a formally valid inference rule.
+    """
+
+    @staticmethod
+    def copy(warrant: Warrant) -> WarrantTransfer:
+        return WarrantTransfer(
+            operation=WarrantOperation.COPY,
+            input_warrant=warrant,
+            output_warrant=warrant,
+            rule_id="warrant.copy.v1",
+            explanation="Identity transformation; no warrant is created or destroyed.",
+        )
+
+    @staticmethod
+    def paraphrase(warrant: Warrant, fidelity: float = 1.0) -> WarrantTransfer:
+        fidelity = _clamp(fidelity)
+        output = warrant.model_copy(update={
+            "support": min(warrant.support, fidelity),
+            "entailment": min(warrant.entailment, fidelity),
+        })
+        return WarrantTransfer(
+            operation=WarrantOperation.PARAPHRASE,
+            input_warrant=warrant,
+            output_warrant=output,
+            rule_id="warrant.paraphrase.v1",
+            explanation="Paraphrase cannot increase warrant; imperfect fidelity may reduce it.",
+        )
+
+    @staticmethod
+    def summarize(warrant: Warrant, retention: float) -> WarrantTransfer:
+        retention = _clamp(retention)
+        output = warrant.model_copy(update={
+            "support": warrant.support * retention,
+            "entailment": warrant.entailment * retention,
+            "scope_validity": warrant.scope_validity * retention,
+        })
+        return WarrantTransfer(
+            operation=WarrantOperation.SUMMARIZE,
+            input_warrant=warrant,
+            output_warrant=output,
+            rule_id="warrant.summarize.v1",
+            explanation="Summarization can omit qualifiers and therefore cannot improve warrant.",
+        )
+
+    @staticmethod
+    def deduce(premises: Iterable[Warrant], formal_validity: float) -> WarrantTransfer:
+        items = tuple(premises)
+        if not items:
+            raise ValueError("Deduction requires at least one premise")
+        validity = _clamp(formal_validity)
+        premise_support = min(item.usable_support for item in items)
+        contradiction = max(item.contradiction for item in items)
+        output_support = min(premise_support, validity)
+        output = Warrant(
+            support=output_support,
+            contradiction=contradiction,
+            entailment=validity,
+            temporal_validity=min(item.temporal_validity for item in items),
+            scope_validity=min(item.scope_validity for item in items),
+            independence=min(item.independence for item in items),
+            provenance_integrity=min(item.provenance_integrity for item in items),
+            reproducibility=min(item.reproducibility for item in items),
+            falsifiability=min(item.falsifiability for item in items),
+        )
+        aggregate = _aggregate_warrant(items)
+        return WarrantTransfer(
+            operation=WarrantOperation.DEDUCE,
+            input_warrant=aggregate,
+            output_warrant=output,
+            rule_id="warrant.deduce.v1",
+            explanation="Formal deduction is bounded by the weakest usable premise and formal validity.",
+        )
+
+    @staticmethod
+    def corroborate(warrants: Iterable[Warrant], independence: float) -> WarrantTransfer:
+        items = tuple(warrants)
+        if not items:
+            raise ValueError("Corroboration requires at least one witness")
+        independence = _clamp(independence)
+        base = _aggregate_warrant(items)
+        marginal = 1.0 - prod(1.0 - _clamp(item.usable_support) for item in items)
+        output_support = min(1.0, base.support + (marginal - base.support) * independence)
+        output = base.model_copy(update={
+            "support": output_support,
+            "independence": independence,
+        })
+        return WarrantTransfer(
+            operation=WarrantOperation.CORROBORATE,
+            input_warrant=base,
+            output_warrant=output,
+            rule_id="warrant.corroborate.v1",
+            explanation="Independent corroboration may add warrant; correlated witnesses contribute less.",
+        )
+
+    @staticmethod
+    def contradict(warrant: Warrant, contradiction_strength: float) -> WarrantTransfer:
+        contradiction_strength = _clamp(contradiction_strength)
+        output = warrant.model_copy(update={
+            "contradiction": max(warrant.contradiction, contradiction_strength),
+        })
+        return WarrantTransfer(
+            operation=WarrantOperation.CONTRADICT,
+            input_warrant=warrant,
+            output_warrant=output,
+            rule_id="warrant.contradict.v1",
+            explanation="Counterevidence increases explicit contradiction rather than deleting support.",
+        )
+
+    @staticmethod
+    def speculate(warrant: Warrant) -> WarrantTransfer:
+        output = warrant.model_copy(update={
+            "support": 0.0,
+            "entailment": 0.0,
+            "provenance_integrity": min(warrant.provenance_integrity, 0.25),
+        })
+        return WarrantTransfer(
+            operation=WarrantOperation.SPECULATE,
+            input_warrant=warrant,
+            output_warrant=output,
+            rule_id="warrant.speculate.v1",
+            explanation="A hypothesis is useful for search but does not inherit factual warrant automatically.",
+        )
+
+
+def _aggregate_warrant(items: tuple[Warrant, ...]) -> Warrant:
+    return Warrant(
+        support=max(item.support for item in items),
+        contradiction=max(item.contradiction for item in items),
+        entailment=min(item.entailment for item in items),
+        temporal_validity=min(item.temporal_validity for item in items),
+        scope_validity=min(item.scope_validity for item in items),
+        independence=min(item.independence for item in items),
+        provenance_integrity=min(item.provenance_integrity for item in items),
+        reproducibility=min(item.reproducibility for item in items),
+        falsifiability=max(item.falsifiability for item in items),
+    )
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))

--- a/thalos_prime/epistemic_v3/witness.py
+++ b/thalos_prime/epistemic_v3/witness.py
@@ -1,0 +1,149 @@
+"""Witness Calculus for causal independence and source genealogy."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Iterable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class WitnessKind(StrEnum):
+    """Origin kind of a witness."""
+
+    OBSERVATION = "observation"
+    DOCUMENT = "document"
+    TESTIMONY = "testimony"
+    RECORD = "record"
+    MEASUREMENT = "measurement"
+    DERIVED = "derived"
+    USER_ASSERTION = "user_assertion"
+    SYNTHETIC = "synthetic"
+
+
+class Witness(BaseModel):
+    """A source-level witness with explicit causal ancestry."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    witness_id: str
+    artifact_id: str
+    kind: WitnessKind
+    issuer: str | None = None
+    observation_time: str | None = None
+    acquisition_time: str | None = None
+    parent_witness_ids: tuple[str, ...] = Field(default_factory=tuple)
+    independence_group: str | None = None
+    eligible: bool = True
+
+    @classmethod
+    def create(
+        cls,
+        artifact_id: str,
+        kind: WitnessKind,
+        *,
+        issuer: str | None = None,
+        observation_time: str | None = None,
+        acquisition_time: str | None = None,
+        parent_witness_ids: Iterable[str] = (),
+        independence_group: str | None = None,
+        eligible: bool = True,
+    ) -> "Witness":
+        parents = tuple(sorted(set(parent_witness_ids)))
+        identity = {
+            "artifact_id": artifact_id,
+            "kind": kind.value,
+            "issuer": issuer,
+            "observation_time": observation_time,
+            "acquisition_time": acquisition_time,
+            "parent_witness_ids": parents,
+            "independence_group": independence_group,
+            "eligible": eligible,
+        }
+        digest = hashlib.sha256(
+            json.dumps(identity, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        return cls(
+            witness_id=f"wit:{digest}",
+            artifact_id=artifact_id,
+            kind=kind,
+            issuer=issuer,
+            observation_time=observation_time,
+            acquisition_time=acquisition_time,
+            parent_witness_ids=parents,
+            independence_group=independence_group,
+            eligible=eligible,
+        )
+
+
+@dataclass(frozen=True)
+class WitnessAnalysis:
+    """Deterministic result of grouping witnesses by causal ancestry."""
+
+    eligible_witness_ids: tuple[str, ...]
+    independent_groups: tuple[tuple[str, tuple[str, ...]], ...]
+    root_lineages: tuple[tuple[str, tuple[str, ...]], ...]
+    independence_score: float
+    correlation_penalty: float
+
+
+class WitnessCalculus:
+    """Compute causal witness diversity rather than counting documents."""
+
+    def __init__(self, witnesses: Iterable[Witness]) -> None:
+        self._witnesses = {w.witness_id: w for w in witnesses}
+        self._validate_acyclic()
+
+    def analyze(self, witness_ids: Iterable[str]) -> WitnessAnalysis:
+        selected = tuple(sorted(set(witness_ids)))
+        eligible = tuple(
+            wid for wid in selected if wid in self._witnesses and self._witnesses[wid].eligible
+        )
+        groups: dict[str, list[str]] = {}
+        roots: dict[str, set[str]] = {}
+        for wid in eligible:
+            witness = self._witnesses[wid]
+            group = witness.independence_group or self._root_signature(wid)
+            groups.setdefault(group, []).append(wid)
+            for root in self._roots(wid):
+                roots.setdefault(root, set()).add(wid)
+
+        group_items = tuple((key, tuple(sorted(value))) for key, value in sorted(groups.items()))
+        root_items = tuple((key, tuple(sorted(value))) for key, value in sorted(roots.items()))
+        n = len(eligible)
+        independent = len(group_items)
+        root_count = len(root_items)
+        independence_score = 0.0 if n == 0 else min(1.0, (independent + root_count) / (2.0 * n))
+        correlation_penalty = 0.0 if n == 0 else 1.0 - (independent / n)
+        return WitnessAnalysis(
+            eligible_witness_ids=eligible,
+            independent_groups=group_items,
+            root_lineages=root_items,
+            independence_score=round(independence_score, 6),
+            correlation_penalty=round(correlation_penalty, 6),
+        )
+
+    def _roots(self, witness_id: str, trail: tuple[str, ...] = ()) -> set[str]:
+        if witness_id in trail:
+            raise ValueError("Witness genealogy contains a cycle")
+        witness = self._witnesses[witness_id]
+        if not witness.parent_witness_ids:
+            return {witness_id}
+        roots: set[str] = set()
+        for parent in witness.parent_witness_ids:
+            if parent not in self._witnesses:
+                raise ValueError(f"Unknown parent witness: {parent}")
+            roots.update(self._roots(parent, trail + (witness_id,)))
+        return roots
+
+    def _root_signature(self, witness_id: str) -> str:
+        roots = sorted(self._roots(witness_id))
+        payload = json.dumps(roots, separators=(",", ":"))
+        return "root:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    def _validate_acyclic(self) -> None:
+        for witness_id in self._witnesses:
+            self._roots(witness_id)

--- a/thalos_prime/mcp/server.py
+++ b/thalos_prime/mcp/server.py
@@ -22,6 +22,7 @@ from thalos_prime.epistemic_core import (
     ThalosEpistemicEngine,
     TrustClass,
 )
+from thalos_prime.mcp.v3_tools import ThalosV3Runtime, register_v3_tools
 
 try:  # Optional dependency; the core remains usable without MCP installed.
     from mcp.server.fastmcp import FastMCP
@@ -46,6 +47,7 @@ class ThalosMcpRuntime:
     evaluations: dict[str, EvidenceEvaluation] = field(default_factory=dict)
     manifests: dict[str, RunManifest] = field(default_factory=dict)
     provenance: ProvenanceGraph = field(default_factory=ProvenanceGraph)
+    v3: ThalosV3Runtime = field(default_factory=ThalosV3Runtime)
 
     def ingest_artifact(
         self,
@@ -316,6 +318,8 @@ def create_mcp_server(runtime: ThalosMcpRuntime | None = None) -> Any:
     mcp.tool(name="thalos.belief.get")(state.get_belief)
     mcp.tool(name="thalos.audit.trace")(state.trace_claim)
     mcp.tool(name="thalos.proof.export")(state.export_proof)
+
+    register_v3_tools(mcp, state.v3)
     return mcp
 
 

--- a/thalos_prime/mcp/v3_tools.py
+++ b/thalos_prime/mcp/v3_tools.py
@@ -7,9 +7,9 @@ from typing import Any
 
 from thalos_prime.epistemic_v3.challenge import ChallengeEngine
 from thalos_prime.epistemic_v3.claim_ir import ClaimCompiler, ClaimIR, ClaimType
-from thalos_prime.epistemic_v3.counterfactual import CounterfactualEngine
-from thalos_prime.epistemic_v3.lattice import BeliefLattice
-from thalos_prime.epistemic_v3.stability import StabilityAnalyzer
+from thalos_prime.epistemic_v3.counterfactual import CounterfactualEngine, CounterfactualReport
+from thalos_prime.epistemic_v3.lattice import BeliefLattice, BeliefPosition
+from thalos_prime.epistemic_v3.stability import StabilityAnalyzer, StabilityReport
 from thalos_prime.epistemic_v3.transaction import EpistemicTransaction
 from thalos_prime.epistemic_v3.vm import DEFAULT_INVESTIGATION_PROGRAM, EpistemicVM
 from thalos_prime.epistemic_v3.warrant import Warrant, WarrantAlgebra, WarrantOperation
@@ -37,10 +37,7 @@ class ThalosV3Runtime:
         if claim_type is not None:
             kwargs["claim_type"] = ClaimType(claim_type)
         result = ClaimCompiler.compile(text, **kwargs)
-        return {
-            "claim": result.claim.model_dump(mode="json"),
-            "warnings": result.warnings,
-        }
+        return {"claim": result.claim.model_dump(mode="json"), "warnings": result.warnings}
 
     def build_challenge_plan(self, *, claim: dict[str, Any]) -> dict[str, Any]:
         compiled = ClaimIR.model_validate(claim)
@@ -192,7 +189,7 @@ class ThalosV3Runtime:
             challenge_plan_id=challenge_plan_id,
             witness_analysis=witness_analysis,
             warrant=Warrant.model_validate(warrant),
-            belief_position=self.lattice.model_validate(belief_position) if hasattr(self.lattice, "model_validate") else _belief_position(belief_position),
+            belief_position=BeliefPosition.model_validate(belief_position),
             stability_report=StabilityReport.model_validate(stability_report),
             counterfactual_report=CounterfactualReport.model_validate(counterfactual_report),
             source_snapshot_id=source_snapshot_id,
@@ -200,12 +197,6 @@ class ThalosV3Runtime:
             proof_bundle_id=proof_bundle_id,
         )
         return transaction.model_dump(mode="json")
-
-
-def _belief_position(value: dict[str, Any]) -> Any:
-    from thalos_prime.epistemic_v3.lattice import BeliefPosition
-
-    return BeliefPosition.model_validate(value)
 
 
 def register_v3_tools(mcp: Any, runtime: ThalosV3Runtime | None = None) -> ThalosV3Runtime:

--- a/thalos_prime/mcp/v3_tools.py
+++ b/thalos_prime/mcp/v3_tools.py
@@ -10,6 +10,7 @@ from thalos_prime.epistemic_v3.claim_ir import ClaimCompiler, ClaimIR, ClaimType
 from thalos_prime.epistemic_v3.counterfactual import CounterfactualEngine
 from thalos_prime.epistemic_v3.lattice import BeliefLattice
 from thalos_prime.epistemic_v3.stability import StabilityAnalyzer
+from thalos_prime.epistemic_v3.transaction import EpistemicTransaction
 from thalos_prime.epistemic_v3.vm import DEFAULT_INVESTIGATION_PROGRAM, EpistemicVM
 from thalos_prime.epistemic_v3.warrant import Warrant, WarrantAlgebra, WarrantOperation
 from thalos_prime.epistemic_v3.witness import Witness, WitnessCalculus
@@ -22,8 +23,8 @@ class ThalosV3Runtime:
     It deliberately does not commit beliefs or mutate the authoritative event
     ledger. The existing transactional runtime remains responsible for durable
     state changes; this layer computes claims, challenges, warrant transforms,
-    lattice positions, stability reports, and counterfactual sensitivity that
-    can be fed into those writes.
+    lattice positions, stability reports, counterfactual sensitivity, and
+    immutable transaction aggregates that can be fed into those writes.
     """
 
     vm: EpistemicVM = field(default_factory=EpistemicVM)
@@ -172,6 +173,40 @@ class ThalosV3Runtime:
         )
         return report.model_dump(mode="json")
 
+    def build_transaction(
+        self,
+        *,
+        claim: dict[str, Any],
+        challenge_plan_id: str,
+        witness_analysis: dict[str, Any],
+        warrant: dict[str, Any],
+        belief_position: dict[str, Any],
+        stability_report: dict[str, Any],
+        counterfactual_report: dict[str, Any],
+        source_snapshot_id: str | None = None,
+        run_id: str | None = None,
+        proof_bundle_id: str | None = None,
+    ) -> dict[str, Any]:
+        transaction = EpistemicTransaction.create(
+            claim=ClaimIR.model_validate(claim),
+            challenge_plan_id=challenge_plan_id,
+            witness_analysis=witness_analysis,
+            warrant=Warrant.model_validate(warrant),
+            belief_position=self.lattice.model_validate(belief_position) if hasattr(self.lattice, "model_validate") else _belief_position(belief_position),
+            stability_report=StabilityReport.model_validate(stability_report),
+            counterfactual_report=CounterfactualReport.model_validate(counterfactual_report),
+            source_snapshot_id=source_snapshot_id,
+            run_id=run_id,
+            proof_bundle_id=proof_bundle_id,
+        )
+        return transaction.model_dump(mode="json")
+
+
+def _belief_position(value: dict[str, Any]) -> Any:
+    from thalos_prime.epistemic_v3.lattice import BeliefPosition
+
+    return BeliefPosition.model_validate(value)
+
 
 def register_v3_tools(mcp: Any, runtime: ThalosV3Runtime | None = None) -> ThalosV3Runtime:
     """Register v3 computational tools on an existing FastMCP server."""
@@ -184,4 +219,5 @@ def register_v3_tools(mcp: Any, runtime: ThalosV3Runtime | None = None) -> Thalo
     mcp.tool(name="thalos.v3.warrant.transform")(state.transform_warrant)
     mcp.tool(name="thalos.v3.stability.analyze")(state.stability_report)
     mcp.tool(name="thalos.v3.counterfactual.analyze")(state.counterfactual_report)
+    mcp.tool(name="thalos.v3.transaction.build")(state.build_transaction)
     return state

--- a/thalos_prime/mcp/v3_tools.py
+++ b/thalos_prime/mcp/v3_tools.py
@@ -6,12 +6,13 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from thalos_prime.epistemic_v3.challenge import ChallengeEngine
-from thalos_prime.epistemic_v3.claim_ir import ClaimCompiler
+from thalos_prime.epistemic_v3.claim_ir import ClaimCompiler, ClaimIR, ClaimType
+from thalos_prime.epistemic_v3.counterfactual import CounterfactualEngine
 from thalos_prime.epistemic_v3.lattice import BeliefLattice
 from thalos_prime.epistemic_v3.stability import StabilityAnalyzer
 from thalos_prime.epistemic_v3.vm import DEFAULT_INVESTIGATION_PROGRAM, EpistemicVM
-from thalos_prime.epistemic_v3.warrant import Warrant, WarrantAlgebra
-from thalos_prime.epistemic_v3.witness import Witness, WitnessCalculus, WitnessKind
+from thalos_prime.epistemic_v3.warrant import Warrant, WarrantAlgebra, WarrantOperation
+from thalos_prime.epistemic_v3.witness import Witness, WitnessCalculus
 
 
 @dataclass
@@ -21,18 +22,18 @@ class ThalosV3Runtime:
     It deliberately does not commit beliefs or mutate the authoritative event
     ledger. The existing transactional runtime remains responsible for durable
     state changes; this layer computes claims, challenges, warrant transforms,
-    lattice positions, and stability reports that can be fed into those writes.
+    lattice positions, stability reports, and counterfactual sensitivity that
+    can be fed into those writes.
     """
 
     vm: EpistemicVM = field(default_factory=EpistemicVM)
     lattice: BeliefLattice = field(default_factory=BeliefLattice)
     stability: StabilityAnalyzer = field(default_factory=StabilityAnalyzer)
+    counterfactual: CounterfactualEngine = field(default_factory=CounterfactualEngine)
 
     def compile_claim(self, *, text: str, claim_type: str | None = None) -> dict[str, Any]:
         kwargs: dict[str, Any] = {}
         if claim_type is not None:
-            from thalos_prime.epistemic_v3.claim_ir import ClaimType
-
             kwargs["claim_type"] = ClaimType(claim_type)
         result = ClaimCompiler.compile(text, **kwargs)
         return {
@@ -41,8 +42,6 @@ class ThalosV3Runtime:
         }
 
     def build_challenge_plan(self, *, claim: dict[str, Any]) -> dict[str, Any]:
-        from thalos_prime.epistemic_v3.claim_ir import ClaimIR
-
         compiled = ClaimIR.model_validate(claim)
         return ChallengeEngine.build_plan(compiled).model_dump(mode="json")
 
@@ -79,7 +78,14 @@ class ThalosV3Runtime:
 
     def analyze_witnesses(self, *, witnesses: list[dict[str, Any]], witness_ids: list[str]) -> dict[str, Any]:
         parsed = [Witness.model_validate(witness) for witness in witnesses]
-        return WitnessCalculus(parsed).analyze(witness_ids).to_dict() if hasattr(WitnessCalculus(parsed).analyze(witness_ids), "to_dict") else _witness_analysis_dict(WitnessCalculus(parsed).analyze(witness_ids))
+        analysis = WitnessCalculus(parsed).analyze(witness_ids)
+        return {
+            "eligible_witness_ids": analysis.eligible_witness_ids,
+            "independent_groups": analysis.independent_groups,
+            "root_lineages": analysis.root_lineages,
+            "independence_score": analysis.independence_score,
+            "correlation_penalty": analysis.correlation_penalty,
+        }
 
     def transform_warrant(
         self,
@@ -89,34 +95,32 @@ class ThalosV3Runtime:
         warrants: list[dict[str, Any]] | None = None,
         parameter: float | None = None,
     ) -> dict[str, Any]:
-        from thalos_prime.epistemic_v3.warrant import WarrantOperation
-
         op = WarrantOperation(operation)
-        if op.value == "copy":
+        if op is WarrantOperation.COPY:
             if warrant is None:
                 raise ValueError("copy requires warrant")
             transfer = WarrantAlgebra.copy(Warrant.model_validate(warrant))
-        elif op.value == "paraphrase":
+        elif op is WarrantOperation.PARAPHRASE:
             if warrant is None:
                 raise ValueError("paraphrase requires warrant")
             transfer = WarrantAlgebra.paraphrase(Warrant.model_validate(warrant), parameter or 1.0)
-        elif op.value == "summarize":
+        elif op is WarrantOperation.SUMMARIZE:
             if warrant is None:
                 raise ValueError("summarize requires warrant")
             transfer = WarrantAlgebra.summarize(Warrant.model_validate(warrant), parameter or 1.0)
-        elif op.value == "deduce":
+        elif op is WarrantOperation.DEDUCE:
             if not warrants:
                 raise ValueError("deduce requires warrants")
             transfer = WarrantAlgebra.deduce([Warrant.model_validate(item) for item in warrants], parameter or 1.0)
-        elif op.value == "corroborate":
+        elif op is WarrantOperation.CORROBORATE:
             if not warrants:
                 raise ValueError("corroborate requires warrants")
             transfer = WarrantAlgebra.corroborate([Warrant.model_validate(item) for item in warrants], parameter or 0.0)
-        elif op.value == "contradict":
+        elif op is WarrantOperation.CONTRADICT:
             if warrant is None:
                 raise ValueError("contradict requires warrant")
             transfer = WarrantAlgebra.contradict(Warrant.model_validate(warrant), parameter or 0.0)
-        elif op.value == "speculate":
+        elif op is WarrantOperation.SPECULATE:
             if warrant is None:
                 raise ValueError("speculate requires warrant")
             transfer = WarrantAlgebra.speculate(Warrant.model_validate(warrant))
@@ -139,8 +143,7 @@ class ThalosV3Runtime:
         decisions: dict[str, str],
     ) -> dict[str, Any]:
         def decide(ids: tuple[str, ...]) -> str:
-            key = "|".join(ids)
-            return decisions.get(key, baseline_decision)
+            return decisions.get("|".join(ids), baseline_decision)
 
         report = self.stability.analyze(
             evidence_ids=evidence_ids,
@@ -150,15 +153,24 @@ class ThalosV3Runtime:
         )
         return report.model_dump(mode="json")
 
+    def counterfactual_report(
+        self,
+        *,
+        evidence_ids: list[str],
+        baseline_decision: str,
+        decisions: dict[str, str],
+        max_removal_order: int = 2,
+    ) -> dict[str, Any]:
+        def decide(ids: tuple[str, ...]) -> str:
+            return decisions.get("|".join(ids), baseline_decision)
 
-def _witness_analysis_dict(analysis: Any) -> dict[str, Any]:
-    return {
-        "eligible_witness_ids": analysis.eligible_witness_ids,
-        "independent_groups": analysis.independent_groups,
-        "root_lineages": analysis.root_lineages,
-        "independence_score": analysis.independence_score,
-        "correlation_penalty": analysis.correlation_penalty,
-    }
+        engine = CounterfactualEngine(max_removal_order=max_removal_order)
+        report = engine.analyze(
+            evidence_ids=evidence_ids,
+            baseline_decision=baseline_decision,
+            decide=decide,
+        )
+        return report.model_dump(mode="json")
 
 
 def register_v3_tools(mcp: Any, runtime: ThalosV3Runtime | None = None) -> ThalosV3Runtime:
@@ -171,4 +183,5 @@ def register_v3_tools(mcp: Any, runtime: ThalosV3Runtime | None = None) -> Thalo
     mcp.tool(name="thalos.v3.witness.analyze")(state.analyze_witnesses)
     mcp.tool(name="thalos.v3.warrant.transform")(state.transform_warrant)
     mcp.tool(name="thalos.v3.stability.analyze")(state.stability_report)
+    mcp.tool(name="thalos.v3.counterfactual.analyze")(state.counterfactual_report)
     return state

--- a/thalos_prime/mcp/v3_tools.py
+++ b/thalos_prime/mcp/v3_tools.py
@@ -8,6 +8,7 @@ from typing import Any
 from thalos_prime.epistemic_v3.challenge import ChallengeEngine
 from thalos_prime.epistemic_v3.claim_ir import ClaimCompiler, ClaimIR, ClaimType
 from thalos_prime.epistemic_v3.counterfactual import CounterfactualEngine, CounterfactualReport
+from thalos_prime.epistemic_v3.decision import DecisionCompiler
 from thalos_prime.epistemic_v3.lattice import BeliefLattice, BeliefPosition
 from thalos_prime.epistemic_v3.stability import StabilityAnalyzer, StabilityReport
 from thalos_prime.epistemic_v3.transaction import EpistemicTransaction
@@ -23,14 +24,16 @@ class ThalosV3Runtime:
     It deliberately does not commit beliefs or mutate the authoritative event
     ledger. The existing transactional runtime remains responsible for durable
     state changes; this layer computes claims, challenges, warrant transforms,
-    lattice positions, stability reports, counterfactual sensitivity, and
-    immutable transaction aggregates that can be fed into those writes.
+    lattice positions, decision artifacts, stability reports,
+    counterfactual sensitivity, and immutable transaction aggregates that can
+    be fed into those writes.
     """
 
     vm: EpistemicVM = field(default_factory=EpistemicVM)
     lattice: BeliefLattice = field(default_factory=BeliefLattice)
     stability: StabilityAnalyzer = field(default_factory=StabilityAnalyzer)
     counterfactual: CounterfactualEngine = field(default_factory=CounterfactualEngine)
+    decision: DecisionCompiler = field(default_factory=DecisionCompiler)
 
     def compile_claim(self, *, text: str, claim_type: str | None = None) -> dict[str, Any]:
         kwargs: dict[str, Any] = {}
@@ -60,6 +63,20 @@ class ThalosV3Runtime:
             failed_challenge_count=failed_challenge_count,
         )
         return position.model_dump(mode="json")
+
+    def compile_decision(
+        self,
+        *,
+        belief_position: dict[str, Any],
+        stability_report: dict[str, Any],
+        counterfactual_report: dict[str, Any],
+    ) -> dict[str, Any]:
+        artifact = self.decision.compile(
+            belief=BeliefPosition.model_validate(belief_position),
+            stability=StabilityReport.model_validate(stability_report),
+            counterfactual=CounterfactualReport.model_validate(counterfactual_report),
+        )
+        return artifact.model_dump(mode="json")
 
     def run_program(self, *, query: str, warrant: dict[str, Any], challenge_count: int = 0) -> dict[str, Any]:
         result = self.vm.execute(
@@ -205,6 +222,7 @@ def register_v3_tools(mcp: Any, runtime: ThalosV3Runtime | None = None) -> Thalo
     mcp.tool(name="thalos.v3.claim.compile")(state.compile_claim)
     mcp.tool(name="thalos.v3.challenge.plan")(state.build_challenge_plan)
     mcp.tool(name="thalos.v3.belief.classify")(state.classify_belief)
+    mcp.tool(name="thalos.v3.decision.compile")(state.compile_decision)
     mcp.tool(name="thalos.v3.program.run")(state.run_program)
     mcp.tool(name="thalos.v3.witness.analyze")(state.analyze_witnesses)
     mcp.tool(name="thalos.v3.warrant.transform")(state.transform_warrant)

--- a/thalos_prime/mcp/v3_tools.py
+++ b/thalos_prime/mcp/v3_tools.py
@@ -1,0 +1,174 @@
+"""MCP-facing adapters for the Thalos Prime epistemic v3 engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from thalos_prime.epistemic_v3.challenge import ChallengeEngine
+from thalos_prime.epistemic_v3.claim_ir import ClaimCompiler
+from thalos_prime.epistemic_v3.lattice import BeliefLattice
+from thalos_prime.epistemic_v3.stability import StabilityAnalyzer
+from thalos_prime.epistemic_v3.vm import DEFAULT_INVESTIGATION_PROGRAM, EpistemicVM
+from thalos_prime.epistemic_v3.warrant import Warrant, WarrantAlgebra
+from thalos_prime.epistemic_v3.witness import Witness, WitnessCalculus, WitnessKind
+
+
+@dataclass
+class ThalosV3Runtime:
+    """State-free computational adapter for the new epistemic substrate.
+
+    It deliberately does not commit beliefs or mutate the authoritative event
+    ledger. The existing transactional runtime remains responsible for durable
+    state changes; this layer computes claims, challenges, warrant transforms,
+    lattice positions, and stability reports that can be fed into those writes.
+    """
+
+    vm: EpistemicVM = field(default_factory=EpistemicVM)
+    lattice: BeliefLattice = field(default_factory=BeliefLattice)
+    stability: StabilityAnalyzer = field(default_factory=StabilityAnalyzer)
+
+    def compile_claim(self, *, text: str, claim_type: str | None = None) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {}
+        if claim_type is not None:
+            from thalos_prime.epistemic_v3.claim_ir import ClaimType
+
+            kwargs["claim_type"] = ClaimType(claim_type)
+        result = ClaimCompiler.compile(text, **kwargs)
+        return {
+            "claim": result.claim.model_dump(mode="json"),
+            "warnings": result.warnings,
+        }
+
+    def build_challenge_plan(self, *, claim: dict[str, Any]) -> dict[str, Any]:
+        from thalos_prime.epistemic_v3.claim_ir import ClaimIR
+
+        compiled = ClaimIR.model_validate(claim)
+        return ChallengeEngine.build_plan(compiled).model_dump(mode="json")
+
+    def classify_belief(
+        self,
+        *,
+        claim_id: str,
+        warrant: dict[str, Any],
+        challenge_count: int = 0,
+        resolved_challenge_count: int = 0,
+        failed_challenge_count: int = 0,
+    ) -> dict[str, Any]:
+        position = self.lattice.classify(
+            claim_id=claim_id,
+            warrant=Warrant.model_validate(warrant),
+            challenge_count=challenge_count,
+            resolved_challenge_count=resolved_challenge_count,
+            failed_challenge_count=failed_challenge_count,
+        )
+        return position.model_dump(mode="json")
+
+    def run_program(self, *, query: str, warrant: dict[str, Any], challenge_count: int = 0) -> dict[str, Any]:
+        result = self.vm.execute(
+            DEFAULT_INVESTIGATION_PROGRAM,
+            {
+                "query": query,
+                "warrant": Warrant.model_validate(warrant),
+                "challenge_count": challenge_count,
+                "resolved_challenge_count": 0,
+                "failed_challenge_count": 0,
+            },
+        )
+        return result.model_dump(mode="json")
+
+    def analyze_witnesses(self, *, witnesses: list[dict[str, Any]], witness_ids: list[str]) -> dict[str, Any]:
+        parsed = [Witness.model_validate(witness) for witness in witnesses]
+        return WitnessCalculus(parsed).analyze(witness_ids).to_dict() if hasattr(WitnessCalculus(parsed).analyze(witness_ids), "to_dict") else _witness_analysis_dict(WitnessCalculus(parsed).analyze(witness_ids))
+
+    def transform_warrant(
+        self,
+        *,
+        operation: str,
+        warrant: dict[str, Any] | None = None,
+        warrants: list[dict[str, Any]] | None = None,
+        parameter: float | None = None,
+    ) -> dict[str, Any]:
+        from thalos_prime.epistemic_v3.warrant import WarrantOperation
+
+        op = WarrantOperation(operation)
+        if op.value == "copy":
+            if warrant is None:
+                raise ValueError("copy requires warrant")
+            transfer = WarrantAlgebra.copy(Warrant.model_validate(warrant))
+        elif op.value == "paraphrase":
+            if warrant is None:
+                raise ValueError("paraphrase requires warrant")
+            transfer = WarrantAlgebra.paraphrase(Warrant.model_validate(warrant), parameter or 1.0)
+        elif op.value == "summarize":
+            if warrant is None:
+                raise ValueError("summarize requires warrant")
+            transfer = WarrantAlgebra.summarize(Warrant.model_validate(warrant), parameter or 1.0)
+        elif op.value == "deduce":
+            if not warrants:
+                raise ValueError("deduce requires warrants")
+            transfer = WarrantAlgebra.deduce([Warrant.model_validate(item) for item in warrants], parameter or 1.0)
+        elif op.value == "corroborate":
+            if not warrants:
+                raise ValueError("corroborate requires warrants")
+            transfer = WarrantAlgebra.corroborate([Warrant.model_validate(item) for item in warrants], parameter or 0.0)
+        elif op.value == "contradict":
+            if warrant is None:
+                raise ValueError("contradict requires warrant")
+            transfer = WarrantAlgebra.contradict(Warrant.model_validate(warrant), parameter or 0.0)
+        elif op.value == "speculate":
+            if warrant is None:
+                raise ValueError("speculate requires warrant")
+            transfer = WarrantAlgebra.speculate(Warrant.model_validate(warrant))
+        else:
+            raise ValueError(f"unsupported warrant operation: {operation}")
+        return {
+            "operation": transfer.operation.value,
+            "input_warrant": transfer.input_warrant.model_dump(mode="json"),
+            "output_warrant": transfer.output_warrant.model_dump(mode="json"),
+            "rule_id": transfer.rule_id,
+            "explanation": transfer.explanation,
+            "conserved": transfer.conserved,
+        }
+
+    def stability_report(
+        self,
+        *,
+        evidence_ids: list[str],
+        baseline_decision: str,
+        decisions: dict[str, str],
+    ) -> dict[str, Any]:
+        def decide(ids: tuple[str, ...]) -> str:
+            key = "|".join(ids)
+            return decisions.get(key, baseline_decision)
+
+        report = self.stability.analyze(
+            evidence_ids=evidence_ids,
+            baseline_decision=baseline_decision,
+            decide=decide,
+            max_removals=1,
+        )
+        return report.model_dump(mode="json")
+
+
+def _witness_analysis_dict(analysis: Any) -> dict[str, Any]:
+    return {
+        "eligible_witness_ids": analysis.eligible_witness_ids,
+        "independent_groups": analysis.independent_groups,
+        "root_lineages": analysis.root_lineages,
+        "independence_score": analysis.independence_score,
+        "correlation_penalty": analysis.correlation_penalty,
+    }
+
+
+def register_v3_tools(mcp: Any, runtime: ThalosV3Runtime | None = None) -> ThalosV3Runtime:
+    """Register v3 computational tools on an existing FastMCP server."""
+    state = runtime or ThalosV3Runtime()
+    mcp.tool(name="thalos.v3.claim.compile")(state.compile_claim)
+    mcp.tool(name="thalos.v3.challenge.plan")(state.build_challenge_plan)
+    mcp.tool(name="thalos.v3.belief.classify")(state.classify_belief)
+    mcp.tool(name="thalos.v3.program.run")(state.run_program)
+    mcp.tool(name="thalos.v3.witness.analyze")(state.analyze_witnesses)
+    mcp.tool(name="thalos.v3.warrant.transform")(state.transform_warrant)
+    mcp.tool(name="thalos.v3.stability.analyze")(state.stability_report)
+    return state

--- a/thalos_prime/mcp/v3_tools.py
+++ b/thalos_prime/mcp/v3_tools.py
@@ -8,7 +8,7 @@ from typing import Any
 from thalos_prime.epistemic_v3.challenge import ChallengeEngine
 from thalos_prime.epistemic_v3.claim_ir import ClaimCompiler, ClaimIR, ClaimType
 from thalos_prime.epistemic_v3.counterfactual import CounterfactualEngine, CounterfactualReport
-from thalos_prime.epistemic_v3.decision import DecisionCompiler
+from thalos_prime.epistemic_v3.decision import DecisionArtifact, DecisionCompiler
 from thalos_prime.epistemic_v3.lattice import BeliefLattice, BeliefPosition
 from thalos_prime.epistemic_v3.stability import StabilityAnalyzer, StabilityReport
 from thalos_prime.epistemic_v3.transaction import EpistemicTransaction
@@ -195,6 +195,7 @@ class ThalosV3Runtime:
         witness_analysis: dict[str, Any],
         warrant: dict[str, Any],
         belief_position: dict[str, Any],
+        decision_artifact: dict[str, Any],
         stability_report: dict[str, Any],
         counterfactual_report: dict[str, Any],
         source_snapshot_id: str | None = None,
@@ -207,6 +208,7 @@ class ThalosV3Runtime:
             witness_analysis=witness_analysis,
             warrant=Warrant.model_validate(warrant),
             belief_position=BeliefPosition.model_validate(belief_position),
+            decision_artifact=DecisionArtifact.model_validate(decision_artifact),
             stability_report=StabilityReport.model_validate(stability_report),
             counterfactual_report=CounterfactualReport.model_validate(counterfactual_report),
             source_snapshot_id=source_snapshot_id,


### PR DESCRIPTION
## Summary

Adds the first implementation of the new Thalos Prime epistemic-computing architecture as a stacked change on top of the existing epistemic/MCP foundation.

### New computational substrate

- Claim IR and deterministic Claim Compiler
- Witness Calculus with causal genealogy and correlation detection
- Warrant Algebra with explicit transformation rules
- Falsification Shadow / Challenge Engine
- Multidimensional Belief Lattice
- Deterministic Epistemic VM
- Perturbation Stability Analyzer
- Counterfactual evidence / decision-flip engine
- Auditable Decision Compiler with explicit reason codes
- Immutable content-addressed Epistemic Transaction aggregate that includes the final Decision Artifact

### Integration

- v3 computational MCP tools
- v3 investigation Skill
- plugin manifest capabilities
- expanded epistemic CI workflow
- executable unit tests for v3, transaction, counterfactual, and decision layers
- architecture documentation

### Design boundary

The v3 layer remains computation-only. Durable belief writes remain behind the existing transactional runtime and authorization boundary.

The final policy decision is now part of the immutable epistemic transaction itself, preventing the transaction from being assembled from one computational state while a different decision artifact is committed.

This PR is intentionally stacked on `agent/epistemic-core-mcp-foundation` so the underlying persistence/MCP foundation and the new v3 epistemic substrate can be reviewed independently.

### Validation status

The focused CI workflow and tests have been added and expanded, but no GitHub Actions run is currently visible for the latest head through the connected GitHub API. The current commit reports a pending Vercel status. The implementation should therefore be treated as **not yet CI-verified** until the repository's CI system executes successfully.